### PR TITLE
Remove hardcoded references to microsoft from mail templates

### DIFF
--- a/api/createRepo.ts
+++ b/api/createRepo.ts
@@ -511,7 +511,7 @@ async function sendEmail(req: IReposAppRequestWithCreateResponse, logic: ICustom
     isNotBootstrap: true,
   });
   try {
-    mail.content = await RenderHtmlMail(config.typescript.appDirectory, emailTemplate, contentOptions);
+    mail.content = await RenderHtmlMail(config.typescript.appDirectory, emailTemplate, contentOptions, config);
   } catch (renderError) {
     req.insights.trackException({
       exception: renderError,
@@ -556,7 +556,7 @@ async function sendEmail(req: IReposAppRequestWithCreateResponse, logic: ICustom
     additionalMail.to = operationsMails;
     contentOptions.reason = `You are receiving this e-mail as the operations contact address(es) ${operationsMails.join(', ')}. A repo has been created or classified.`;
     try {
-      additionalMail.content = await RenderHtmlMail(config.typescript.appDirectory, emailTemplate, contentOptions);
+      additionalMail.content = await RenderHtmlMail(config.typescript.appDirectory, emailTemplate, contentOptions, config);
     } catch (renderError) {
       console.dir(renderError);
       return;

--- a/business/operations/index.ts
+++ b/business/operations/index.ts
@@ -1049,7 +1049,7 @@ export class Operations
 
   async emailRender(emailViewName: string, contentOptions: any): Promise<string> {
     const appDirectory = this.config.typescript.appDirectory;
-    return await RenderHtmlMail(appDirectory, emailViewName, contentOptions);
+    return await RenderHtmlMail(appDirectory, emailViewName, contentOptions, this.config);
   }
 }
 

--- a/config/brand.json
+++ b/config/brand.json
@@ -2,6 +2,7 @@
   "companyName": "env://COMPANY_NAME?default=your enterprise",
   "companyLink": "env://COMPANY_LINK?default=about:blank",
   "companyPortalName": "env://COMPANY_PORTAL_NAME?default=GitHub Management Portal",
+  "companyLogoSrc": "env://COMPANY_LOGO_SRC",
   "appName": "env://APP_NAME?default=Self-service GitHub Management",
   "supportMail": "env://PORTAL_ADMIN_EMAIL",
   "operationsMail": "env://GITHUB_OPERATIONS_EMAIL",

--- a/jobs/reports/mailer.ts
+++ b/jobs/reports/mailer.ts
@@ -25,7 +25,7 @@ interface IReportRenderOptions {
   to: string;
   github: {
     consolidated: any;
-  }
+  };
   pretty?: boolean;
   basedir?: string;
   viewServices: any;
@@ -137,7 +137,7 @@ async function sendReport(context: IReportsContext, mailProvider: IMailProvider,
     notification,
   };
   const basedir = context.settings.basedir;
-  const mailContent = await emailRender(basedir, 'report', viewOptions);
+  const mailContent = await emailRender(basedir, 'report', viewOptions, app.config);
   // Store the e-mail instead of sending
   if (overrideSendWithPath) {
     const filename = path.join(overrideSendWithPath, `${address}.html`);

--- a/lib/emailRender.ts
+++ b/lib/emailRender.ts
@@ -5,15 +5,15 @@
 const path = require('path');
 const pug = require('pug');
 
-export default function RenderHtmlMail(basedir, viewName, options): Promise<string> {
+export default function RenderHtmlMail(basedir, viewName, options, config): Promise<string> {
   return new Promise((resolve, reject) => {
-    return renderMailHtml(basedir, viewName, options, (error, html) => {
+    return renderMailHtml(basedir, viewName, options, config, (error, html) => {
       return error ? reject(error) : resolve(html);
     });
   });
 }
 
-function renderMailHtml(basedir, viewName, options, callback) {
+function renderMailHtml(basedir, viewName, options, config, callback) {
   options = options || {};
   if (!viewName) {
     viewName = 'email';
@@ -26,6 +26,7 @@ function renderMailHtml(basedir, viewName, options, callback) {
     const view = path.join(basedir, `views/email/${viewName}.pug`);
     options.pretty = true;
     options.basedir = basedir;
+    options.config = config;
     html = pug.renderFile(view, options);
   } catch (renderError) {
     return callback(renderError);

--- a/lib/mailProvider/index.ts
+++ b/lib/mailProvider/index.ts
@@ -73,7 +73,7 @@ export function createMailProviderInstance(config): IMailProvider {
     if (mailProvider) {
       if (mailConfig.overrideRecipient) {
         patchOverride(mailProvider, mailConfig.overrideRecipient, mailProvider.html);
-      }    
+      }
       return mailProvider;
     }
   }
@@ -86,7 +86,7 @@ export function createMailProviderInstance(config): IMailProvider {
   }
   switch (provider) {
     case 'smtpMailService': {
-      mailProvider = new SmtpMailService(config);
+      mailProvider = new SmtpMailService(mailConfig);
       break;
     }
     case 'mockMailService': {

--- a/lib/mailProvider/smtpMailService.ts
+++ b/lib/mailProvider/smtpMailService.ts
@@ -24,7 +24,7 @@ export default class SmtpMailService implements IMailProvider {
   async initialize() {}
 
   async sendMail(mail: IMail): Promise<any> {
-    if (!this._config.customSmtpService) {
+    if (!this._config.smtpMailService) {
       throw new Error('SMTP Mail configuration not given, mail sending failed');
     }
     const transporter = nodemailer.createTransport(this._config.smtpMailService);

--- a/routes/org/team/approval/index.ts
+++ b/routes/org/team/approval/index.ts
@@ -185,7 +185,7 @@ export async function postActionDecision(providers: IProviders, individualContex
     const getDecisionEmailViewName = engine.getDecisionEmailViewName();
     let content = null;
     try {
-      content = await RenderHtmlMail(config.typescript.appDirectory, getDecisionEmailViewName, contentOptions);
+      content = await RenderHtmlMail(config.typescript.appDirectory, getDecisionEmailViewName, contentOptions, config);
     } catch (renderError) {
     }
     if (content) {

--- a/views/email/footer.pug
+++ b/views/email/footer.pug
@@ -42,12 +42,12 @@
             p.footer
               | #{companyName} Open Source Programs Office
               br
-              a(href='https://aka.ms/opensource') aka.ms/opensource
+              a(href=config.urls.explore) Explore
               | &nbsp;&bull;&nbsp;
-              a(href='https://stackoverflow.microsoft.com/tags/opensource') StackOverflow@Microsoft
+              a(href=config.urls.docs) Docs
               | &nbsp;&bull;&nbsp;
-              a(href='mailto:opensource@microsoft.com') opensource@microsoft.com
+              a(href='mailto:' + config.brand.supportMail) #{config.brand.supportMail}
 
           td(width='120', valign='middle')
-            img(align='right', valign='middle', src='https://ospomail.azureedge.net/microsoft.png', width='108', height='23', alt='Microsoft')
+            img(align='right', valign='middle', src=config.brand.companyLogoSrc, width='108', alt=companyName)
 

--- a/views/email/header.pug
+++ b/views/email/header.pug
@@ -6,8 +6,8 @@ table(style='width:100%;border:0', cellspacing=0, cellpadding=0)
   tbody
     tr
       td(width=orgIdSize, height=orgIdSize)
-        img(src=logo, width=orgIdSize, height=orgIdSize, alt='Microsoft Open Source')
+        img(src=logo, width=orgIdSize, height=orgIdSize, alt=config.brand.companyName + 'Open Source')
       td(valign='bottom', nowrap='nowrap')
         h2(style='vertical-align:bottom')
           | &nbsp;
-          = app || 'Microsoft Open Source'
+          = app || config.brand.companyName + 'Open Source'

--- a/views/email/newrepolockdown.pug
+++ b/views/email/newrepolockdown.pug
@@ -120,7 +120,7 @@ block content
 
     if lockdownMailContent.repository && lockdownMailContent.repository.fork
       h3 FORK
-      p This repository was forked. A fork into an official Microsoft organization is a very big deal and can cause confusion with the upstream open source community. Please verify that the individual creating this repo intends for their business to maintain this new forked open source community. If this is just a fork to contribute, engineers should contribute from their own individual account fork.
+      p This repository was forked. A fork into an official #{config.brand.companyName} organization is a very big deal and can cause confusion with the upstream open source community. Please verify that the individual creating this repo intends for their business to maintain this new forked open source community. If this is just a fork to contribute, engineers should contribute from their own individual account fork.
 
     if isForkAdministratorLocked
       h4 For operations use

--- a/views/email/newrepolockremoved.pug
+++ b/views/email/newrepolockremoved.pug
@@ -29,10 +29,10 @@ block content
           | Do not remove any copyright headers or license information. Do not change the license from the forked project without the permission of #[a(href='mailto:OSSStandardsLegal@service.microsoft.com') OSS CELA].
         li
           strong Modifications.
-          | If you are modifying the project, follow our #[a(href='https://docs.opensource.microsoft.com/content/index.html') register] workflow for business/CELA approval.
+          | If you are modifying the project, follow our #[a(href=config.urls.docs) register] workflow for business/CELA approval.
         li
-          strong Making a Fork Microsoft's.
-          | If you are making a "hard" fork that you plan on supporting as its own Microsoft project, follow our #[a(href='https://docs.opensource.microsoft.com/content/releasing/index.html') release] workflow for business/CELA approval.
+          strong Making a Fork #{config.brand.companyName}'s.
+          | If you are making a "hard" fork that you plan on supporting as its own #{config.brand.companyName} project, follow our #[a(href=config.urls.release) release] workflow for business/CELA approval.
           ul: li
             strong Note:
             | the exception to this workflow for a fork is that the license must remain the same as the upstream fork. Contact #[a(href='mailto:OSSStandardsLegal@service.microsoft.com') OSS CELA] with questions.

--- a/webhooks/tasks/automaticTeams.ts
+++ b/webhooks/tasks/automaticTeams.ts
@@ -230,7 +230,7 @@ async function sendEmail(config, insights, basedir, mailProvider: IMailProvider,
   };
   let mailContent = null;
   try {
-    mailContent = await RenderHtmlMail(basedir, 'largeTeamProtected', body);
+    mailContent = await RenderHtmlMail(basedir, 'largeTeamProtected', body, config);
   } catch (renderError) {
     insights.trackException({
       exception: renderError,


### PR DESCRIPTION
* Fix SmtpMailService config
* Introduce new variable for company logo source
* Pass config to RenderHtmlMail calls to access variables inside pug templates
* Replace some occuences of hardcoded Microsoft strings for config variables