### PR TITLE
ci: Update versions and targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v
+        uses: actions/setup-node@v3
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   CodeQL-Build:
-    strategy:
-      fail-fast: false
-
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   pull_request:
-    branches: [develop]
+    branches: [main]
 
 jobs:
   # Build a Docker container to validate the build

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - uses: docker/build-push-action@v3


### PR DESCRIPTION
Could split these out separately, but figured their semi-related:
- unpin the actions versions, so there is less Dependabot noise, except for a new major version
- Remove a strategy key, that only applies when a `matrix` value is used
- Update a the container job, since it was only running for a non-existant develop branch