### PR TITLE
chore: use lint-staged for ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+default-assets-package/thirdparty/**/*.js
+default-assets-package/public/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,5 +45,4 @@ module.exports = {
       },
     },
   ],
-  ignorePatterns: ['default-assets-package/thirdparty/**/*.js', 'dist/**/*.js'],
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "**/*": "prettier --write --ignore-unknown"
+    "*": "prettier --write --ignore-unknown",
+    "*.{js,ts}": "eslint --fix"
   },
   "jest-junit": {
     "suiteNameTemplate": "{filepath}",


### PR DESCRIPTION
Moved the ignores to the separate file, so they should be easier for IDEs to pick up at the same time.