### PR TITLE
ci: use built-in NPM cache with setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v3
+        with:
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Probably won't make a major differene to the build time, but doesn't hurt