### PR TITLE
fix: ESLint no-undef

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,11 +4,9 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.js'],
-      rules: {
-        'no-undef': 'off',
-      },
       env: {
         es6: true,
+        node: true,
       },
     },
     {

--- a/config/corporate.trainingResources.js
+++ b/config/corporate.trainingResources.js
@@ -27,8 +27,8 @@ module.exports = function (graphApi) {
 
   // 1: load URL/resource links from a parallel painless config environment
   if (pkg && pkg[painlessConfigEnvPkgName] && environmentName) {
+    let pkgName = pkg[painlessConfigEnvPkgName];
     try {
-      let pkgName = pkg[painlessConfigEnvPkgName];
       if (pkgName.startsWith('./')) {
         pkgName = path.join(typescriptConfig.appDirectory, pkgName);
       }

--- a/config/github.templates.js
+++ b/config/github.templates.js
@@ -44,8 +44,8 @@ module.exports = (graphApi) => {
 
   if (templateSourceType === 'fs') {
     templates.directory = path.join(typescriptConfig.appDirectory, templates.directory);
+    const filename = path.join(templates.directory, 'definitions.json');
     try {
-      const filename = path.join(templates.directory, 'definitions.json');
       const str = fs.readFileSync(filename, 'utf8');
       templates.definitions = JSON.parse(str);
     } catch (notFound) {

--- a/views/js/search.js
+++ b/views/js/search.js
@@ -1,3 +1,4 @@
+/* eslint-env browser,jquery */
 var timer;
 var inputQuery = $('#inputQuery');
 inputQuery.on('keyup input', function () {


### PR DESCRIPTION
Mostly were for environment variables that weren't automatically exposed, but a few were referencing things that didn't exist in scope