### PR TITLE
fix: no-useless-escape

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
         'no-ex-assign': 'off',
         'no-inner-declarations': 'off',
         'no-useless-catch': 'off',
-        'no-useless-escape': 'off',
         'prefer-const': 'off',
         'prefer-rest-params': 'off',
         'prefer-spread': 'off',

--- a/business/team.ts
+++ b/business/team.ts
@@ -592,7 +592,7 @@ export class Team {
     const customTypeFilteringParameter = options.type;
     if (customTypeFilteringParameter && customTypeFilteringParameter !== GitHubRepositoryType.Sources) {
       throw new Error(
-        `Custom \'type\' parameter is specified, but at this time only \'sources\' is a valid enum value. Value: ${customTypeFilteringParameter}`
+        `Custom 'type' parameter is specified, but at this time only 'sources' is a valid enum value. Value: ${customTypeFilteringParameter}`
       );
     }
     if (!this.slug) {

--- a/entities/teamJoinApproval/teamJoinApproval.ts
+++ b/entities/teamJoinApproval/teamJoinApproval.ts
@@ -395,7 +395,7 @@ EntityMetadataMappings.Register(
         WHERE
           ${entityTypeColumn} = $1 AND
           ${metadataColumnName}->>'teamid' IN ( ${groupSet} ) AND
-          ${metadataColumnName} @> \$${++valueCounter}
+          ${metadataColumnName} @> $${++valueCounter}
       `;
         values = [entityTypeValue, ...stringOrNumberArrayAsStringArray(ids), { active: true }];
         return { sql, values };

--- a/lib/caching/blob.ts
+++ b/lib/caching/blob.ts
@@ -62,7 +62,7 @@ export default class BlobCache implements ICacheHelper {
 
   private getBlobName(key: string, extension: string) {
     key = key.replace(/W\//g, ''); // stript the W/ from e-tags
-    key = key.replace(/[@,\(\)\\\?#:=]/g, '/');
+    key = key.replace(/[@,()\\?#:=]/g, '/');
     key = key.replace(/\/\//g, '/');
     return `${key}${extension}`;
   }

--- a/lib/caching/cosmosdb.ts
+++ b/lib/caching/cosmosdb.ts
@@ -54,7 +54,7 @@ export default class CosmosCache implements ICacheHelper {
   }
 
   private safetyKey(str: string) {
-    return str.replace(/[%:\\\/\?#]/g, '');
+    return str.replace(/[%:\\/?#]/g, '');
   }
 
   private key(key: string) {

--- a/lib/github/composite.ts
+++ b/lib/github/composite.ts
@@ -142,7 +142,7 @@ export class CompositeIntelligentEngine extends IntelligentEngine {
           const refreshWindow = moment(refreshingIso).add(secondsToAllowForRefresh, 'seconds');
           if (moment().utc().isAfter(refreshWindow)) {
             debug(
-              `Another worker\'s refresh did not complete. Refreshing in this instance. ${apiContext.redisKey.metadata}`
+              `Another worker's refresh did not complete. Refreshing in this instance. ${apiContext.redisKey.metadata}`
             );
           } else {
             shouldRefresh = false;

--- a/lib/github/restApi.ts
+++ b/lib/github/restApi.ts
@@ -373,7 +373,7 @@ export class IntelligentGitHubEngine extends IntelligentEngine {
           const refreshWindow = moment(refreshingIso).add(secondsToAllowForRefresh, 'seconds');
           if (moment().utc().isAfter(refreshWindow)) {
             debug(
-              `Another worker\'s refresh did not complete. Refreshing in this instance. ${apiContext.redisKey.metadata}`
+              `Another worker's refresh did not complete. Refreshing in this instance. ${apiContext.redisKey.metadata}`
             );
           } else {
             shouldRefresh = false;

--- a/lib/linkProviders/postgres/postgresLinkProvider.ts
+++ b/lib/linkProviders/postgres/postgresLinkProvider.ts
@@ -296,7 +296,7 @@ export class PostgresLinkProvider implements ILinkProvider {
       .map((columnName) => {
         values.push(updates[columnName]);
         const index = values.length;
-        return `\n        ${columnName} = \$${index}`;
+        return `\n        ${columnName} = $${index}`;
       })
       .join();
     let sql = `


### PR DESCRIPTION
Some characters don't need to be escaped anymore inside the string templates, and regex characters don't need escaping inside the `[]` ranges