### PR TITLE
chore: enable no-constant-condition

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         'no-case-declarations': 'off',
-        'no-constant-condition': 'off',
         'no-empty': 'off',
         'no-ex-assign': 'off',
         'no-inner-declarations': 'off',

--- a/jobs/firehose/task.ts
+++ b/jobs/firehose/task.ts
@@ -126,6 +126,7 @@ export default async function firehose({ providers, started }: IReposJob): Promi
     }
     console.log(`[thread ${threadNumber}] started`);
     try {
+      // eslint-disable-next-line no-constant-condition
       while (true) {
         await iterate(providers, threadNumber);
       }


### PR DESCRIPTION
I think the one usage is probably intented, but the inline disable probably makes more sense