### PR TITLE
Fix bug in the teamPager.

### DIFF
--- a/routes/teamsPager.ts
+++ b/routes/teamsPager.ts
@@ -55,7 +55,7 @@ async function getTeamsData(
 
   const yourTeamsMap = new Map();
   const overview = await userContext.getAggregatedOverview();
-  if (overview.teams && overview.teams.member.length) {
+  if (overview.teams && (overview.teams.member.length || overview.teams.maintainer.length)) {
     reduceTeams(overview.teams, 'member', yourTeamsMap);
     reduceTeams(overview.teams, 'maintainer', yourTeamsMap);
   }


### PR DESCRIPTION
Conditional logic in the teamPager route only renders teams if the user is a `member` of at least one team.  If a user is a `maintainer` of all of their teams and never a `member` no teams display when selecting "Your Teams."

## Current logic
![image](https://user-images.githubusercontent.com/1141646/199262621-3884eefd-62e5-4ced-94d5-e0556ad11cff.png)



<img width="1219" alt="image" src="https://user-images.githubusercontent.com/1141646/199262022-74a95575-45a9-450e-a316-1cb499d44423.png">


## Updated logic
![image](https://user-images.githubusercontent.com/1141646/199260845-bd91156f-3caa-48e6-aa59-3c35dae863cf.png)
