### PR TITLE
Fix bug not showing orgs the user is an admin of.  Fixes #491.

### DIFF
--- a/user/aggregate.ts
+++ b/user/aggregate.ts
@@ -36,7 +36,7 @@ export interface IAggregateUserOrganizations extends IKnownAggregateUserOrganiza
 export interface IKnownAggregateUserOrganizations {
   member: Organization[];
   admin: Organization[];
-  // in: TODO
+  in: Organization[];
   // pending: TODO
 }
 
@@ -139,9 +139,10 @@ export class UserContext {
     }
     known.admin = known.admin.sort(insensitiveSortOrganizations);
     known.member = known.member.sort(insensitiveSortOrganizations);
+    known.in = Array.prototype.concat(known.admin, known.member);
     // Available organizations
     const all = new Set(this._operations.organizations.values());
-    for (const o of known.member) {
+    for (const o of known.in) {
       all.delete(o);
     }
     known.available = Array.from(all).sort(insensitiveSortOrganizations);
@@ -187,7 +188,7 @@ export class UserContext {
       SettleToStateValue(this.aggregateLegacyRepositories()),
     ]);
     const results: IAggregateUserSummary = {
-      organizations: organizations.value || { member: [], admin: [], available: [] },
+      organizations: organizations.value || { member: [], admin: [], available: [], in: [] },
       teams: teams.value || { maintainer: [], member: [] },
       repos: repositories.value || { byTeam: [] },
     };
@@ -291,6 +292,7 @@ export class UserContext {
     const state: IKnownAggregateUserOrganizations = {
       admin: [],
       member: [],
+      in: [],
     };
     for (const { organization, role } of membership) {
       if (role !== OrganizationMembershipRole.Admin && role !== OrganizationMembershipRole.Member) {
@@ -385,7 +387,9 @@ export class UserContext {
     const state: IKnownAggregateUserOrganizations = {
       admin: admin.map((name) => this._operations.getOrganization(name)),
       member: member.map((name) => this._operations.getOrganization(name)),
+      in: [],
     };
+    state.in = Array.prototype.concat(state.admin, state.member);
     return state;
   }
 }

--- a/views/index.pug
+++ b/views/index.pug
@@ -57,14 +57,14 @@ block content
                         h3 2-factor auth
                         p PROTECTED
 
-      if onboarding !== true && overview && overview.organizations && overview.organizations.member && overview.organizations.member.length
+      if onboarding !== true && overview && overview.organizations && (overview.organizations.in && overview.organizations.in.length)
         h1
           a.a-unstyled(name='orgs') Your #{config.brand.companyName} GitHub organization memberships
       else
         h4 You've successfully linked your #{config.brand.companyName} and GitHub accounts.
 
       - var currentPriority = ''
-      - var oom = overview && overview.organizations ? overview.organizations.member : []
+      - var oom = overview && overview.organizations ? overview.organizations.in : []
       each o in oom
           div.link-box
             a(href=o.name + onboardingPostfixUrl)


### PR DESCRIPTION
```sql
-- confirm only admin roles exist
select count(*), metadata->>'role' from organizationmembercache group by metadata->>'role'; ;
```

|count|role|
|-|-|
|4|admin|

Before this commit, orgs that a user is an admin of show up in the “available organizations” area.

![before](https://user-images.githubusercontent.com/1141646/206715584-4760a461-dfd5-4872-8195-58672f993cc0.png)

After this commit, those orgs show up as orgs the uers is a member of.

![after](https://user-images.githubusercontent.com/1141646/206715645-29c91342-c1f5-4903-bdd6-4751c08f0d04.png)

> **Note**:
>  I have not performed an exhaustive analysis to see if the new `in` logic should be used in any other views.
