### PR TITLE
Update index page to include locked orgs.

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -228,7 +228,7 @@ block content
                   - currentPriority = o.priority
                   //-if currentPriority == 'secondary'
                 //-if o.locked === true // o.membershipStateTemporary !== 'active'
-                if o.locked === true || o.hidden === true
+                if o.hidden === true
                   //- Do not show by invitation only orgs at this time
                 else
                   div.link-box
@@ -237,7 +237,11 @@ block content
                         h6.text-muted
                           strong(style='text-decoration: underline')= o.name
                           = ' '
-                          small: span.label.label-muted Join
+                          small: span.label.label-muted 
+                            if o.locked === true
+                              | By invitation only
+                            else
+                              | Join
                         if true || onboarding === true
                           p: small= o.nativeUrl
                         p.small.text-mute= o.description


### PR DESCRIPTION
This PR enables users to also see locked orgs as well, but visualizes them differently than open orgs.  

<img width="423" alt="image" src="https://user-images.githubusercontent.com/1141646/206719760-b2d14453-16e7-474c-b0c8-b520af4b8698.png">
