### PR TITLE
Supporting more app types, client flights

### DIFF
--- a/api/client/context/administration/index.ts
+++ b/api/client/context/administration/index.ts
@@ -7,10 +7,9 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Organization } from '../../../../business/organization';
 import { ReposAppRequest } from '../../../../interfaces';
-import { jsonError } from '../../../../middleware';
+import { getIsCorporateAdministrator, jsonError } from '../../../../middleware';
 import getCompanySpecificDeployment from '../../../../middleware/companySpecificDeployment';
 import { ErrorHelper, getProviders } from '../../../../transitional';
-import { IndividualContext } from '../../../../user';
 
 import routeIndividualOrganization from './organization';
 
@@ -22,12 +21,7 @@ interface IRequestWithAdministration extends ReposAppRequest {
 
 router.use(
   asyncHandler(async (req: IRequestWithAdministration, res, next) => {
-    const { operations } = getProviders(req);
-    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
-    req.isSystemAdministrator = await operations.isSystemAdministrator(
-      activeContext?.corporateIdentity?.id,
-      activeContext?.corporateIdentity?.username
-    );
+    req.isSystemAdministrator = await getIsCorporateAdministrator(req);
     return next();
   })
 );

--- a/api/client/context/approvals.ts
+++ b/api/client/context/approvals.ts
@@ -87,8 +87,9 @@ router.get(
       if (corporateId === request.corporateId) {
         return res.json(approvalPairToJson({ request, team }));
       }
-      const isOrgSudoer = await organization.isSudoer(username, activeContext.link);
-      isMaintainer = isOrgSudoer;
+      const isPortalSudoer = await operations.isPortalSudoer(username, activeContext.link);
+      const isOrgSudoer = isPortalSudoer || (await organization.isSudoer(username, activeContext.link));
+      isMaintainer = isPortalSudoer || isOrgSudoer;
       const maintainers = await team.getOfficialMaintainers();
       if (!isMaintainer) {
         for (let i = 0; i < maintainers.length; i++) {

--- a/api/client/organization/annotations.ts
+++ b/api/client/organization/annotations.ts
@@ -1,0 +1,297 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { jsonError } from '../../../middleware/jsonError';
+import {
+  AuthorizeOnlyCorporateAdministrators,
+  checkIsCorporateAdministrator,
+  getIsCorporateAdministrator,
+} from '../../../middleware';
+import {
+  IReposAppRequestWithOrganizationManagementType,
+  OrganizationManagementType,
+} from '../../../middleware/business/organization';
+import {
+  IOrganizationAnnotationChange,
+  OrganizationAnnotation,
+} from '../../../entities/organizationAnnotation';
+import { ErrorHelper, getProviders } from '../../../transitional';
+import { IndividualContext } from '../../../user';
+import { IProviders } from '../../../interfaces';
+
+const router: Router = Router();
+
+type IRequestWithOrganizationAnnotations = IReposAppRequestWithOrganizationManagementType & {
+  annotations: OrganizationAnnotation;
+};
+
+router.use(
+  '/',
+  checkIsCorporateAdministrator,
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { organizationAnnotationsProvider } = getProviders(req);
+    const { organization, organizationManagementType, organizationProfile } = req;
+    const organizationId =
+      organizationManagementType === OrganizationManagementType.Managed
+        ? organization.id
+        : organizationProfile.id;
+    try {
+      req.annotations = await organizationAnnotationsProvider.getAnnotations(organizationId);
+    } catch (error) {
+      if (!ErrorHelper.IsNotFound(error)) {
+        return next(error);
+      }
+    }
+    return next();
+  })
+);
+
+router.get(
+  '/',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    // Limited redaction
+    const isSystemAdministrator = await getIsCorporateAdministrator(req);
+    if (!isSystemAdministrator && annotations.administratorNotes) {
+      annotations.administratorNotes = '*****';
+    }
+    if (!isSystemAdministrator && annotations?.history?.length > 0) {
+      delete annotations.history;
+    }
+    return res.json({
+      isSystemAdministrator,
+      annotations,
+    });
+  })
+);
+
+async function ensureAnnotations(req: IRequestWithOrganizationAnnotations, res, next) {
+  if (!req.annotations) {
+    const { organizationAnnotationsProvider } = getProviders(req);
+    try {
+      const annotations = new OrganizationAnnotation();
+      annotations.organizationId = req.organizationProfile.id;
+      annotations.created = new Date();
+      await organizationAnnotationsProvider.insertAnnotations(annotations);
+      req.annotations = annotations;
+    } catch (error) {
+      return next(error);
+    }
+  }
+  return next();
+}
+
+router.patch('*', AuthorizeOnlyCorporateAdministrators, ensureAnnotations);
+router.put('*', AuthorizeOnlyCorporateAdministrators, ensureAnnotations);
+
+router.put(
+  '/',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    // No-op mostly, since ensureAnnotations precedes
+    return res.json({
+      annotations: req.annotations,
+    });
+  })
+);
+
+function addChangeNote(
+  changes: IOrganizationAnnotationChange[],
+  context: IndividualContext,
+  fieldName: string,
+  beforeAsText: string,
+  afterAsText: string,
+  optionalText?: string
+) {
+  const beforeText = beforeAsText || '(none)';
+  const afterText = afterAsText || '(none)';
+  const changedByDisplay =
+    context.corporateIdentity?.displayName ||
+    context.corporateIdentity?.username ||
+    context.corporateIdentity?.id ||
+    'unknown';
+  changes.push({
+    date: new Date(),
+    corporateId: context.corporateIdentity.id,
+    displayName: context.corporateIdentity?.displayName,
+    text: optionalText || `${changedByDisplay} updated ${fieldName}`,
+    details: `${changedByDisplay} changed ${fieldName} from "${beforeText}" to "${afterText}"`,
+  });
+}
+
+// Properties
+
+router.put(
+  '/property/:propertyName',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    const providers = getProviders(req);
+    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
+    const changes: IOrganizationAnnotationChange[] = [];
+    const newValue = req.body.value as string;
+    if (!newValue) {
+      return next(jsonError('body.value required', 400));
+    }
+    if (typeof newValue !== 'string') {
+      return next(jsonError('body.value must be a string value', 400));
+    }
+    const propertyName = req.params.propertyName as string;
+    const currentPropertyValue = annotations.properties[propertyName] || null;
+    const updateDescription = `Changing property ${propertyName} value from "${currentPropertyValue}" to "${newValue}"`;
+    annotations.properties[propertyName] = newValue;
+    addChangeNote(changes, activeContext, 'property', currentPropertyValue, newValue, updateDescription);
+    const updated = await applyPatch(providers, annotations, changes);
+    return res.json({
+      annotations,
+      updated,
+    });
+  })
+);
+
+router.delete(
+  '/property/:propertyName',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    const providers = getProviders(req);
+    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
+    const changes: IOrganizationAnnotationChange[] = [];
+    const propertyName = req.params.propertyName as string;
+    const currentPropertyValue = annotations.properties[propertyName] || null;
+    if (annotations.properties[propertyName] === undefined) {
+      return next(jsonError(`property ${propertyName} is not set`, 400));
+    }
+    delete annotations.properties[propertyName];
+    addChangeNote(
+      changes,
+      activeContext,
+      'property',
+      currentPropertyValue,
+      null,
+      `Removed the ${propertyName} property`
+    );
+    const updated = await applyPatch(providers, annotations, changes);
+    return res.json({
+      annotations,
+      updated,
+    });
+  })
+);
+
+// Feature flags
+
+router.put(
+  '/feature/:flag',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    const providers = getProviders(req);
+    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
+    const changes: IOrganizationAnnotationChange[] = [];
+    const flag = req.params.flag as string;
+    if (annotations.features.includes(flag)) {
+      return next(jsonError(`The feature flag ${flag} is already present`, 400));
+    }
+    annotations.features.push(flag);
+    addChangeNote(
+      changes,
+      activeContext,
+      'feature flags',
+      `did not have ${flag} feature`,
+      `${flag} feature added`,
+      `Added the ${flag} flag`
+    );
+    const updated = await applyPatch(providers, annotations, changes);
+    return res.json({
+      annotations,
+      updated,
+    });
+  })
+);
+
+router.delete(
+  '/feature/:flag',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    const providers = getProviders(req);
+    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
+    const changes: IOrganizationAnnotationChange[] = [];
+    const flag = req.params.flag as string;
+    if (!annotations.features.includes(flag)) {
+      return next(jsonError(`The feature flag ${flag} is not set`, 400));
+    }
+    annotations.features = annotations.features.filter((f) => f !== flag);
+    addChangeNote(
+      changes,
+      activeContext,
+      'feature flags',
+      `${flag} feature`,
+      `${flag} feature removed`,
+      `Removed the ${flag} flag`
+    );
+    const updated = await applyPatch(providers, annotations, changes);
+    return res.json({
+      annotations,
+      updated,
+    });
+  })
+);
+
+// General values patch
+
+router.patch(
+  '/',
+  asyncHandler(async (req: IRequestWithOrganizationAnnotations, res, next) => {
+    const { annotations } = req;
+    const providers = getProviders(req);
+    const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
+    const changes: IOrganizationAnnotationChange[] = [];
+    const { administratorNotes, notes } = req.body;
+    if (administratorNotes !== undefined && administratorNotes !== annotations.administratorNotes) {
+      addChangeNote(
+        changes,
+        activeContext,
+        'administrator notes',
+        annotations.administratorNotes,
+        administratorNotes
+      );
+      annotations.administratorNotes = administratorNotes;
+    }
+    if (notes !== undefined && notes !== annotations.notes) {
+      addChangeNote(changes, activeContext, 'notes', annotations.notes, notes);
+      annotations.notes = notes;
+    }
+    const updated = await applyPatch(providers, annotations, changes);
+    return res.json({
+      annotations,
+      updated,
+    });
+  })
+);
+
+async function applyPatch(
+  providers: IProviders,
+  annotations: OrganizationAnnotation,
+  changes: IOrganizationAnnotationChange[]
+) {
+  if (changes.length) {
+    changes.reverse();
+    annotations.history = [...changes, ...annotations.history];
+    annotations.updated = new Date();
+    const { organizationAnnotationsProvider } = providers;
+    await organizationAnnotationsProvider.replaceAnnotations(annotations);
+  }
+  return changes.length > 0;
+}
+
+// directOwnersIds, directOwnersSecurityGroupId
+// features, properties
+// flag
+
+router.use('*', (req, res, next) => {
+  return next(jsonError('no API or function available within the organization annotations route', 404));
+});
+
+export default router;

--- a/api/client/organization/index.ts
+++ b/api/client/organization/index.ts
@@ -6,14 +6,21 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
-import RouteRepos from './repos';
-import RouteTeams from './teams';
-import RoutePeople from './people';
-import RouteNewRepoMetadata from './newRepoMetadata';
 import { ReposAppRequest } from '../../../interfaces';
 import { jsonError } from '../../../middleware';
 import getCompanySpecificDeployment from '../../../middleware/companySpecificDeployment';
 import { getProviders } from '../../../transitional';
+import {
+  blockIfUnmanagedOrganization,
+  IReposAppRequestWithOrganizationManagementType,
+  OrganizationManagementType,
+} from '../../../middleware/business/organization';
+
+import routeRepos from './repos';
+import routeTeams from './teams';
+import routePeople from './people';
+import routeNewRepoMetadata from './newRepoMetadata';
+import routeAnnotations from './annotations';
 
 const router: Router = Router();
 
@@ -21,17 +28,12 @@ const deployment = getCompanySpecificDeployment();
 deployment?.routes?.api?.organization?.index && deployment?.routes?.api?.organization?.index(router);
 
 router.get(
-  '/',
-  asyncHandler(async (req: ReposAppRequest, res, next) => {
-    const { organization } = req;
-    return res.json(organization.asClientJson());
-  })
-);
-
-router.get(
   '/accountDetails',
-  asyncHandler(async (req: ReposAppRequest, res) => {
-    const { organization } = req;
+  asyncHandler(async (req: IReposAppRequestWithOrganizationManagementType, res) => {
+    const { organization, organizationProfile, organizationManagementType } = req;
+    if (organizationManagementType === OrganizationManagementType.Unmanaged) {
+      return res.json(organizationProfile);
+    }
     const entity = organization.getEntity();
     if (entity) {
       return res.json(entity);
@@ -41,10 +43,49 @@ router.get(
   })
 );
 
-router.use('/repos', RouteRepos);
-router.use('/teams', RouteTeams);
-router.use('/people', RoutePeople);
-router.use('/newRepoMetadata', RouteNewRepoMetadata);
+/*
+asClientJson() {
+    // TEMP: TEMP: TEMP: not long-term as currently designed
+    const values = {
+      active: this.active,
+      createRepositoriesOnGitHub: this.createRepositoriesOnGitHub,
+      description: this.description,
+      externalMembersPermitted: this.externalMembersPermitted,
+      id: this.id,
+      locked: this.locked,
+      hidden: this.hidden,
+      appOnly: this.isAppOnly,
+      name: this.name,
+      priority: this.priority,
+      privateEngineering: this.privateEngineering,
+      management: this.getManagementApproach(),
+    };
+*/
+router.get(
+  '/',
+  asyncHandler(async (req: IReposAppRequestWithOrganizationManagementType, res, next) => {
+    const { organization, organizationProfile, organizationManagementType } = req;
+    if (organizationManagementType === OrganizationManagementType.Unmanaged) {
+      return res.json({
+        managementType: req.organizationManagementType,
+        id: organizationProfile.id,
+      });
+    }
+    return res.json({
+      managementType: req.organizationManagementType,
+      ...organization.asClientJson(),
+    });
+  })
+);
+
+router.use('/annotations', routeAnnotations);
+
+router.use(blockIfUnmanagedOrganization);
+
+router.use('/repos', routeRepos);
+router.use('/teams', routeTeams);
+router.use('/people', routePeople);
+router.use('/newRepoMetadata', routeNewRepoMetadata);
 
 router.get('/newRepoBanner', (req: ReposAppRequest, res) => {
   const { config } = getProviders(req);

--- a/business/repositoryProject.ts
+++ b/business/repositoryProject.ts
@@ -5,7 +5,7 @@
 
 import { Repository } from './repository';
 import { wrapError } from '../utils';
-import { AppPurpose } from '../github';
+import { AppPurpose, AppPurposeTypes } from '../github';
 import { CacheDefault, getMaxAgeSeconds } from '.';
 import {
   IOperationsInstance,
@@ -212,7 +212,7 @@ export class RepositoryProject {
     return false;
   }
 
-  private authorizeSpecificPurpose(purpose: AppPurpose): IGetAuthorizationHeader | string {
+  private authorizeSpecificPurpose(purpose: AppPurposeTypes): IGetAuthorizationHeader | string {
     const getAuthorizationHeader = this._getSpecificAuthorizationHeader.bind(
       this,
       purpose

--- a/business/repositoryProjectColumn.ts
+++ b/business/repositoryProjectColumn.ts
@@ -4,7 +4,7 @@
 //
 
 import { CacheDefault, getMaxAgeSeconds, RepositoryIssue } from '.';
-import { AppPurpose } from '../github';
+import { AppPurpose, AppPurposeTypes } from '../github';
 import {
   IOperationsInstance,
   IPurposefulGetAuthorizationHeader,
@@ -136,7 +136,7 @@ export class RepositoryProjectColumn {
     return card;
   }
 
-  private authorizeSpecificPurpose(purpose: AppPurpose): IGetAuthorizationHeader | string {
+  private authorizeSpecificPurpose(purpose: AppPurposeTypes): IGetAuthorizationHeader | string {
     const getAuthorizationHeader = this._getSpecificAuthorizationHeader.bind(
       this,
       purpose

--- a/config/client.flighting.json
+++ b/config/client.flighting.json
@@ -1,5 +1,6 @@
 {
   "enabled": "env://REACT_CLIENT_FLIGHTING_ENABLED?trueIf=1",
+  "divertEveryone": "env://REACT_CLIENT_FLIGHTING_DIVERT_ALL?trueIf=1",
   "corporateIds": "env://REACT_CLIENT_FLIGHT_CORPORATEIDS",
   "featureFlagUsers": "env://REACT_CLIENT_FEATURE_FLAGS"
 }

--- a/config/client.flighting.types.ts
+++ b/config/client.flighting.types.ts
@@ -10,6 +10,8 @@ export type ConfigClientRootFlighting = {
 export type ConfigClientFlighting = {
   enabled: boolean;
 
+  divertEveryone: boolean;
+
   // RICH_TYPE_WARNING: this will break if someone tries overriding with a string/env-var
   corporateIds: string[];
 

--- a/config/entityProviders.json
+++ b/config/entityProviders.json
@@ -3,6 +3,7 @@
   "eventrecord": "env://ENTITY_PROVIDER_EVENT?default=firstconfigured",
   "teamjoin": "env://ENTITY_PROVIDER_TEAM_JOIN?default=firstconfigured",
   "repositorymetadata": "env://ENTITY_PROVIDER_REPOSITORY_METADATA?default=firstconfigured",
+  "organizationannotations": "env://ENTITY_PROVIDER_ORGANIZATION_ANNOTATIONS?default=firstconfigured",
   "organizationsettings": "env://ENTITY_PROVIDER_ORGANIZATION_SETTINGS?default=firstconfigured",
   "organizationmembercache": "env://ENTITY_PROVIDER_ORGANIZATION_MEMBER_CACHE?default=firstconfigured",
   "repository": "env://ENTITY_PROVIDER_REPOSITORY?default=firstconfigured",

--- a/config/entityProviders.types.ts
+++ b/config/entityProviders.types.ts
@@ -12,6 +12,7 @@ export type ConfigEntityProviders = {
   eventrecord: string;
   teamjoin: string;
   repositorymetadata: string;
+  organizationannotations: string;
   organizationsettings: string;
   organizationmembercache: string;
   repository: string;

--- a/config/github.codespaces.json
+++ b/config/github.codespaces.json
@@ -7,7 +7,7 @@
   "authentication": {
     "port": "env://CODESPACES_PORT?default=3000",
     "github": {
-      "enabled": "env://CODESPACES_GITHUB_AUTHENTICATION_ENABLED",
+      "enabled": "env://CODESPACES_GITHUB_AUTHENTICATION_ENABLED?default=1",
       "clientId": "env://CODESPACES_GITHUB_CLIENT_ID",
       "clientSecret": "env://CODESPACES_GITHUB_CLIENT_SECRET",
       "impersonateOverrideEmuAccount": {
@@ -16,7 +16,7 @@
       }
     },
     "aad": {
-      "enabled": "env://CODESPACES_AAD_AUTHENTICATION_ENABLED"
+      "enabled": "env://CODESPACES_AAD_AUTHENTICATION_ENABLED?default=1"
     }
   }
 }

--- a/entities/organizationAnnotation.ts
+++ b/entities/organizationAnnotation.ts
@@ -1,0 +1,279 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+// Organization annotations are a way to store arbitrary data about an
+// organization without us having to manage that organization in this
+// environment.
+
+async function initialize(
+  options?: IOrganizationAnnotationProviderCreateOptions
+): Promise<IOrganizationAnnotationMetadataProvider> {
+  const provider = new OrganizationAnnotationMetadataProvider(options);
+  await provider.initialize();
+  return provider;
+}
+
+export default initialize;
+
+import {
+  IEntityMetadata,
+  EntityMetadataType,
+  IEntityMetadataBaseOptions,
+  EntityMetadataBase,
+} from '../lib/entityMetadataProvider/entityMetadata';
+import { IEntityMetadataFixedQuery, QueryBase } from '../lib/entityMetadataProvider/query';
+import {
+  EntityMetadataMappings,
+  MetadataMappingDefinition,
+} from '../lib/entityMetadataProvider/declarations';
+import { PostgresSettings, PostgresConfiguration } from '../lib/entityMetadataProvider/postgres';
+import { IDictionary } from '../interfaces';
+import { CreateError, ErrorHelper } from '../transitional';
+
+const type = new EntityMetadataType('OrganizationAnnotation');
+const thisProviderType = type;
+type ClassType = OrganizationAnnotation;
+
+const defaultPostgresTableName = 'organizationannotations';
+const organizationId = 'organizationId';
+const primaryKeyFieldName = organizationId;
+
+export enum OrganizationAnnotationProperty {}
+export enum OrganizationAnnotationFeature {}
+
+export interface IOrganizationAnnotationChange {
+  date?: string | Date;
+  corporateId?: string;
+  displayName?: string;
+  details?: string;
+  text: string;
+}
+
+interface IOrganizationAnnotationMetadataProperties {
+  // organizationId: string; // primary ID
+
+  created: any;
+  updated: any;
+
+  properties: any;
+  features: any;
+
+  administratorNotes: any;
+  notes: any;
+
+  directOwnersSecurityGroupId: any;
+  directOwnersIds: any;
+
+  history: any;
+
+  additionalData: any;
+}
+
+class OrganizationAnnotationQueryBase extends QueryBase<OrganizationAnnotation> {
+  constructor(public query: Query) {
+    super();
+  }
+}
+
+// class OrganizationAnnotationQuery<T> extends OrganizationAnnotationQueryBase {
+//   constructor(query: Query, public parameters: T) {
+//     super(query);
+//     if (!this.parameters) {
+//       this.parameters = {} as T;
+//     }
+//   }
+// }
+
+enum Query {
+  All,
+}
+
+class QueryByAll extends OrganizationAnnotationQueryBase {
+  constructor() {
+    super(Query.All);
+  }
+}
+
+const Field: IOrganizationAnnotationMetadataProperties = {
+  // organizationId: 'organizationId'
+  created: 'created',
+  updated: 'updated',
+  properties: 'properties',
+  features: 'features',
+  administratorNotes: 'administratorNotes',
+  notes: 'notes',
+  directOwnersSecurityGroupId: 'directOwnersSecurityGroupId',
+  directOwnersIds: 'directOwnersIds',
+  history: 'history',
+  additionalData: 'additionalData',
+};
+
+const fieldNames = Object.getOwnPropertyNames(Field);
+const nativeFieldNames = []; // fieldNames.filter((x) => x !== Field.additionalData);
+
+export class OrganizationAnnotation implements IOrganizationAnnotationMetadataProperties {
+  organizationId: string;
+
+  created: Date;
+  updated: Date;
+
+  properties: Record<string | OrganizationAnnotationProperty, string>;
+  features: (string | OrganizationAnnotationFeature)[];
+
+  administratorNotes: string;
+  notes: string;
+
+  directOwnersSecurityGroupId: string;
+  directOwnersIds: string[];
+
+  history: IOrganizationAnnotationChange[];
+
+  additionalData: IDictionary<any>;
+
+  constructor() {
+    this.history = [];
+    this.features = [];
+    this.properties = {};
+  }
+
+  hasFeature(feature: string | OrganizationAnnotationFeature): boolean {
+    return this.features.includes(feature);
+  }
+
+  getProperty(key: string | OrganizationAnnotationProperty): string | boolean | number {
+    return this.properties[key];
+  }
+}
+
+EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiate, () => {
+  return new OrganizationAnnotation();
+});
+EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, organizationId);
+
+// NOTE: No memory mapping for this type that is only in Postgres
+
+EntityMetadataMappings.Register(
+  type,
+  PostgresSettings.PostgresDefaultTypeColumnName,
+  defaultPostgresTableName
+);
+PostgresConfiguration.SetDefaultTableName(type, defaultPostgresTableName);
+EntityMetadataMappings.Register(type, PostgresSettings.PostgresDateColumns, [Field.created, Field.updated]);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+PostgresConfiguration.IdentifyNativeFields(type, nativeFieldNames);
+PostgresConfiguration.ValidateMappings(type, fieldNames, [primaryKeyFieldName]);
+
+EntityMetadataMappings.Register(
+  type,
+  PostgresSettings.PostgresQueries,
+  (
+    query: IEntityMetadataFixedQuery,
+    mapMetadataPropertiesToFields: string[],
+    metadataColumnName: string,
+    tableName: string,
+    getEntityTypeColumnValue
+  ) => {
+    const base = query as OrganizationAnnotationQueryBase;
+    switch (base.query) {
+      case Query.All: {
+        return {
+          sql: `
+          SELECT *
+          FROM
+            ${tableName}
+          ORDER BY
+          signed
+        `,
+          values: [],
+        };
+      }
+      default:
+        throw new Error(`The query ${base.query} is not implemented by this provider for the type ${type}`);
+    }
+  }
+);
+
+// Runtime validation of FieldNames
+for (let i = 0; i < fieldNames.length; i++) {
+  const fn = fieldNames[i];
+  if (Field[fn] !== fn) {
+    throw new Error(`Field name ${fn} and value do not match in ${__filename}`);
+  }
+}
+
+export interface IOrganizationAnnotationProviderCreateOptions extends IEntityMetadataBaseOptions {}
+
+export interface IOrganizationAnnotationMetadataProvider {
+  initialize(): Promise<void>;
+  getOrCreateAnnotations(organizationId: string): Promise<ClassType>;
+  getAnnotations(organizationId: string): Promise<ClassType>;
+  insertAnnotations(annotations: ClassType): Promise<string>;
+  deleteAnnotations(annotations: ClassType): Promise<void>;
+  replaceAnnotations(annotations: ClassType): Promise<void>;
+  getAllAnnotations(): Promise<ClassType[]>;
+}
+
+export class OrganizationAnnotationMetadataProvider
+  extends EntityMetadataBase
+  implements IOrganizationAnnotationMetadataProvider
+{
+  constructor(options: IOrganizationAnnotationProviderCreateOptions) {
+    super(thisProviderType, options);
+    EntityImplementation.EnsureDefinitions();
+  }
+
+  async getOrCreateAnnotations(organizationId: string) {
+    try {
+      const annotations = await this.getAnnotations(organizationId);
+      if (annotations) {
+        return annotations;
+      }
+      throw CreateError.NotFound('No metadata');
+    } catch (error) {
+      if (ErrorHelper.IsNotFound(error)) {
+        const emptyMetadata = new OrganizationAnnotation();
+        emptyMetadata.organizationId = organizationId;
+        await this.insertAnnotations(emptyMetadata);
+        return emptyMetadata;
+      }
+      throw error;
+    }
+  }
+
+  async deleteAnnotations(annotations: ClassType): Promise<void> {
+    const entity = this.serialize(thisProviderType, annotations);
+    this._entities.deleteMetadata(entity);
+    await this._entities.updateMetadata(entity);
+  }
+
+  async getAnnotations(organizationId: string): Promise<ClassType> {
+    this.ensureHelpers(thisProviderType);
+    let metadata: IEntityMetadata = null;
+    metadata = await this._entities.getMetadata(thisProviderType, organizationId);
+    return this.deserialize<ClassType>(thisProviderType, metadata);
+  }
+
+  async insertAnnotations(annotations: ClassType): Promise<string> {
+    const entity = this.serialize(thisProviderType, annotations);
+    await this._entities.setMetadata(entity);
+    return entity.entityId;
+  }
+
+  async replaceAnnotations(annotations: ClassType): Promise<void> {
+    const entity = this.serialize(thisProviderType, annotations);
+    await this._entities.updateMetadata(entity);
+  }
+
+  async getAllAnnotations() {
+    const query = new QueryByAll();
+    const data = await this._entities.fixedQueryMetadata(type, query);
+    return this.deserializeArray<ClassType>(thisProviderType, data);
+  }
+}
+
+export const EntityImplementation = {
+  Type: type,
+  EnsureDefinitions: () => {},
+};

--- a/entities/organizationSettings/organizationSetting.ts
+++ b/entities/organizationSettings/organizationSetting.ts
@@ -21,6 +21,7 @@ import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
 export interface IBasicGitHubAppInstallation {
   appId: number;
   installationId: number;
+  appPurposeId?: string;
 }
 
 export enum SpecialTeam {
@@ -30,6 +31,15 @@ export enum SpecialTeam {
   SystemWrite = 'systemWrite', // teamAllReposWrite
   SystemRead = 'systemRead', // teamAllReposRead
   SystemAdmin = 'systemAdmin', // teamAllReposAdmin
+}
+
+export enum OrganizationFeature {
+  Invisible = 'invisible',
+  Ignore = 'ignore',
+}
+
+export enum OrganizationProperty {
+  Priority = 'priority',
 }
 
 export interface ISpecialTeam {
@@ -103,7 +113,7 @@ export class OrganizationSetting implements IOrganizationSettingProperties {
 
   installations: IBasicGitHubAppInstallation[];
   features: string[];
-  properties: any;
+  properties: Record<string | OrganizationProperty, string>;
 
   specialTeams: ISpecialTeam[];
   templates: string[];
@@ -118,11 +128,11 @@ export class OrganizationSetting implements IOrganizationSettingProperties {
     this.legalEntities = [];
   }
 
-  hasFeature(feature: string): boolean {
+  hasFeature(feature: string | OrganizationFeature): boolean {
     return this.features.includes(feature);
   }
 
-  getProperty(key: string): string | boolean | number {
+  getProperty(key: string | OrganizationProperty): string | boolean | number {
     return this.properties[key];
   }
 

--- a/github/appTokens.ts
+++ b/github/appTokens.ts
@@ -7,7 +7,7 @@ import { request } from '@octokit/request';
 import { createAppAuth, InstallationAccessTokenAuthentication } from '@octokit/auth-app';
 import { AppAuthentication, AuthInterface } from '@octokit/auth-app/dist-types/types';
 
-import { AppPurpose } from '.';
+import { AppPurposeTypes } from '.';
 import { IAuthorizationHeaderValue } from '../interfaces';
 
 interface IInstallationToken {
@@ -27,14 +27,14 @@ const ValidityOffsetAfterNowMilliseconds = 1000 * 120; // how long to require va
 export class GitHubAppTokens {
   #privateKey: string;
   private _appId: number;
-  public purpose: AppPurpose;
+  public purpose: AppPurposeTypes;
   private _appAuth: AuthInterface;
   private _installationAuth = new Map<number, AuthInterface>();
   private _tokensByInstallation = new Map<number, IInstallationToken[]>();
   private _baseUrl: string;
 
   static CreateFromBase64EncodedFileString(
-    purpose: AppPurpose,
+    purpose: AppPurposeTypes,
     friendlyName: string,
     applicationId: number,
     fileContents: string,
@@ -45,7 +45,7 @@ export class GitHubAppTokens {
   }
 
   static CreateFromString(
-    purpose: AppPurpose,
+    purpose: AppPurposeTypes,
     friendlyName: string,
     applicationId: number,
     value: string,
@@ -63,7 +63,7 @@ export class GitHubAppTokens {
   }
 
   constructor(
-    purpose: AppPurpose,
+    purpose: AppPurposeTypes,
     public friendlyName: string,
     appId: number,
     privateKey: string,

--- a/github/index.ts
+++ b/github/index.ts
@@ -5,6 +5,8 @@
 
 import { IReposApplication } from '../interfaces';
 
+// TODO: removing the Onboarding type (Ahoy)
+
 export enum AppPurpose {
   Data = 'Data',
   CustomerFacing = 'CustomerFacing',
@@ -16,7 +18,23 @@ export enum AppPurpose {
   Onboarding = 'Onboarding',
 }
 
-export const AllAvailableAppPurposes = [
+export interface ICustomAppPurpose {
+  isCustomAppPurpose: boolean; // basic type check
+  id: string;
+  name: string;
+  configuration: IGitHubAppConfiguration;
+}
+
+export type AppPurposeTypes = AppPurpose | ICustomAppPurpose;
+
+export class CustomAppPurpose implements ICustomAppPurpose {
+  get isCustomAppPurpose() {
+    return true;
+  }
+  constructor(public id: string, public name: string, public configuration: IGitHubAppConfiguration) {}
+}
+
+export const DefinedAppPurposes = [
   AppPurpose.Data,
   AppPurpose.CustomerFacing,
   AppPurpose.Operations,
@@ -27,9 +45,9 @@ export const AllAvailableAppPurposes = [
   AppPurpose.Onboarding,
 ];
 
-export const GitHubAppPurposesExemptFromAllRepositoriesSelection = [AppPurpose.Onboarding];
+// export const GitHubAppPurposesExemptFromAllRepositoriesSelection = [AppPurpose.Onboarding];
 
-export const AppPurposeToConfigurationName = {
+const appPurposeToConfigurationName = {
   [AppPurpose.Data]: 'data',
   [AppPurpose.CustomerFacing]: 'ui',
   [AppPurpose.Operations]: 'operations',
@@ -39,6 +57,46 @@ export const AppPurposeToConfigurationName = {
   [AppPurpose.ActionsData]: 'actions',
   [AppPurpose.Onboarding]: 'onboarding',
 };
+
+export function getAppPurposeId(purpose: AppPurposeTypes) {
+  if ((purpose as ICustomAppPurpose).isCustomAppPurpose === true) {
+    return (purpose as ICustomAppPurpose).id;
+  }
+  const asPurpose = purpose as AppPurpose;
+  const id = appPurposeToConfigurationName[asPurpose];
+  if (!id) {
+    throw new Error(`No configuration name for purpose ${asPurpose}`);
+  }
+  return id;
+}
+
+export class GitHubAppPurposes {
+  private static _instance: GitHubAppPurposes = new GitHubAppPurposes();
+
+  static get AllAvailableAppPurposes() {
+    return this._instance._purposes;
+  }
+
+  static RegisterCustomPurpose(purpose: ICustomAppPurpose) {
+    if (purpose.isCustomAppPurpose !== true) {
+      throw new Error('Purpose must be has isCustomAppPurpose set to true');
+    }
+    if (
+      (this._instance._purposes as ICustomAppPurpose[])
+        .filter((p) => (p as ICustomAppPurpose)?.isCustomAppPurpose === true)
+        .find((p) => p.id === purpose.id)
+    ) {
+      throw new Error(`Purpose with ID ${purpose.id} already registered`);
+    }
+    this._instance._purposes.push(purpose);
+  }
+
+  private _purposes: AppPurposeTypes[];
+
+  constructor() {
+    this._purposes = [...DefinedAppPurposes];
+  }
+}
 
 export enum GitHubAppAuthenticationType {
   ForceSpecificInstallation = 'force',
@@ -54,10 +112,10 @@ export interface IGitHubAppConfiguration {
   webhookSecret?: string;
   slug?: string;
   description?: string;
-  baseUrl: string;
+  baseUrl?: string;
 }
 
 export interface IGitHubAppsOptions {
   app: IReposApplication;
-  configurations: Map<AppPurpose, IGitHubAppConfiguration>;
+  configurations: Map<AppPurposeTypes, IGitHubAppConfiguration>;
 }

--- a/interfaces/github/rest.ts
+++ b/interfaces/github/rest.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { AppPurpose } from '../../github';
+import { AppPurposeTypes } from '../../github';
 
 export interface ICacheOptions {
   backgroundRefresh?: any | null | undefined;
@@ -11,7 +11,7 @@ export interface ICacheOptions {
 }
 
 export interface ICacheOptionsWithPurpose extends ICacheOptions {
-  purpose?: AppPurpose;
+  purpose?: AppPurposeTypes;
 }
 
 export interface IPagedCacheOptions extends ICacheOptions {
@@ -19,7 +19,7 @@ export interface IPagedCacheOptions extends ICacheOptions {
 }
 
 export interface IPurposefulGetAuthorizationHeader {
-  (purpose: AppPurpose): Promise<IAuthorizationHeaderValue>;
+  (purpose: AppPurposeTypes): Promise<IAuthorizationHeaderValue>;
 }
 
 export interface IGetAuthorizationHeader {
@@ -28,7 +28,7 @@ export interface IGetAuthorizationHeader {
 
 export interface IAuthorizationHeaderValue {
   value: string;
-  purpose: AppPurpose;
+  purpose: AppPurposeTypes;
   source?: string;
   installationId?: number;
   organizationName?: string;
@@ -59,6 +59,11 @@ export interface ICacheDefaultTimes {
   orgRepoWebhooksStaleSeconds: number;
   teamRepositoryPermissionStaleSeconds: number;
 }
+
+// These "core capabilities" were created when the GitHub operations
+// classes were refactored to support both GitHub Enterprise Cloud and
+// also GitHub AE. Not all operations are supported by both environments
+// the same.
 
 export enum CoreCapability {
   GitHubRestApi = 'GitHub REST API', // IOperationsGitHubRestLibrary

--- a/interfaces/providers.ts
+++ b/interfaces/providers.ts
@@ -42,6 +42,7 @@ import { ICustomizedNewRepositoryLogic, ICustomizedTeamPermissionsWebhookLogic }
 import { IEntityMetadataProvider } from '../lib/entityMetadataProvider';
 import { IRepositoryProvider } from '../entities/repository';
 import { IKeyVaultSecretResolver } from '../lib/keyVaultResolver';
+import { IOrganizationAnnotationMetadataProvider } from '../entities/organizationAnnotation';
 
 type ProviderGenerator = (value: string) => IEntityMetadataProvider;
 
@@ -73,6 +74,7 @@ export interface IProviders {
   mailAddressProvider?: IMailAddressProvider;
   mailProvider?: IMailProvider;
   operations?: Operations;
+  organizationAnnotationsProvider?: IOrganizationAnnotationMetadataProvider;
   organizationMemberCacheProvider?: IOrganizationMemberCacheProvider;
   organizationSettingsProvider?: IOrganizationSettingProvider;
   postgresPool?: PostgresPool;

--- a/interfaces/web.ts
+++ b/interfaces/web.ts
@@ -32,6 +32,7 @@ export interface IReposAppWithTeam extends ReposAppRequest {
 export enum LocalApiRepoAction {
   Delete = 'delete',
   Archive = 'archive',
+  UnArchive = 'unarchive',
 }
 
 export interface ReposAppRequest extends Request {

--- a/lib/config/environmentConfigurationResolver.ts
+++ b/lib/config/environmentConfigurationResolver.ts
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+import Debug from 'debug';
 import objectPath from 'object-path';
 import { URL } from 'url';
 
@@ -19,15 +20,18 @@ import { URL } from 'url';
 
 const envProtocol = 'env:';
 
+const debug = Debug('config');
+
 export interface IEnvironmentProvider {
   get: (key: string) => string | undefined;
 }
 
 export interface IEnvironmentProviderOptions {
   provider?: IEnvironmentProvider;
+  overrideValues?: Record<string, string>;
 }
 
-type EnvironmentValueType = string | number | boolean | undefined;
+type EnvironmentValueType = string | number | boolean | Date | undefined;
 
 function getUrlIfEnvironmentVariable(value: string) {
   try {
@@ -70,17 +74,24 @@ function identifyPaths(node: any, prefix?: string) {
   return paths;
 }
 
-export function processEnvironmentProvider() {
+export function processEnvironmentProvider(options?: IEnvironmentProviderOptions) {
   return {
     get: (key: string) => {
-      return process.env[key];
+      const { overrideValues } = options || {};
+      if (overrideValues && overrideValues[key] && overrideValues[key] !== process.env[key]) {
+        const overrideOrSetDescriptor = process.env[key] === undefined ? 'Setting' : 'Overriding';
+        debug(
+          `${overrideOrSetDescriptor} environment variable ${key} to .env value "${overrideValues[key]}" instead of value "${process.env[key]}" from process.env`
+        );
+      }
+      return overrideValues && overrideValues[key] ? overrideValues[key] : process.env[key];
     },
   };
 }
 
 function createClient(options: IEnvironmentProviderOptions) {
   options = options || {};
-  const provider = options.provider || processEnvironmentProvider();
+  const provider = options.provider || processEnvironmentProvider(options);
   return {
     resolveObjectVariables: async (object: any) => {
       let paths = null;
@@ -136,9 +147,21 @@ function createClient(options: IEnvironmentProviderOptions) {
               }
               break;
             }
+            case 'date': {
+              variableValue = new Date(currentValue as string);
+              break;
+            }
             case 'integer':
             case 'int': {
-              variableValue = parseInt(currentValue as string, 10);
+              const attemptedValue = parseInt(currentValue as string, 10);
+              if (isNaN(attemptedValue)) {
+                console.warn(
+                  `The value "${currentValue}" for the env:// variable "${variableName}" is not a valid integer. Using the original value instead.`
+                );
+                variableValue = currentValue;
+              } else {
+                variableValue = attemptedValue;
+              }
               break;
             }
             default: {

--- a/lib/config/keyVaultConfigurationResolver.ts
+++ b/lib/config/keyVaultConfigurationResolver.ts
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+import Debug from 'debug';
 import { ClientSecretCredential } from '@azure/identity';
 import { KeyVaultSecret, SecretClient } from '@azure/keyvault-secrets';
 import objectPath from 'object-path';
@@ -30,6 +31,8 @@ import { URL } from 'url';
 // recommended or supported approach for KeyVault use in applications, and may
 // not be endorsed by the engineering team responsible for KeyVault, but for our
 // group and our Node apps, it has been very helpful.
+
+const debug = Debug('config');
 
 const keyVaultProtocol = 'keyvault:';
 const httpsProtocol = 'https:';
@@ -178,6 +181,7 @@ async function getSecretsFromVault(getSecretClient: (vault: string) => Promise<S
           const vaultUrl = uniqueUriToVault.get(uniqueSecretId);
           const secretClient = await getSecretClient(vaultUrl);
           const value = await getSecret(secretClient, secretStash, uniqueSecretId);
+          debug(`Retrieved secret ${uniqueSecretId} value`);
           secretStash.set(uniqueSecretId, value);
         }
       } catch (resolveSecretError) {

--- a/lib/config/painlessConfigAsCode.ts
+++ b/lib/config/painlessConfigAsCode.ts
@@ -4,18 +4,18 @@
 //
 
 import appRoot from 'app-root-path';
-//import Debug from 'debug';
+import Debug from 'debug';
 import dotenv from 'dotenv';
 import path from 'path';
 import walkBack from 'walk-back';
 import { InnerError, IPainlessConfigGet, IProviderOptions } from '.';
 import { processEnvironmentProvider } from './environmentConfigurationResolver';
 
-//const debug = Debug('startup');
+const debug = Debug('config');
+// const debug = (a: any) => {};
 
 const ApplicationNameEnvironmentVariableKey = 'APPLICATION_NAME';
-
-const debug = (a: any) => {};
+const DotEnvOverridesProcessKey = 'PREFER_DOTENV';
 
 function objectProvider(json: any, applicationName: string) {
   const appKey = applicationName ? `app:${applicationName}` : null;
@@ -121,19 +121,41 @@ function tryGetPackage(appRoot: string) {
   }
 }
 
-function preloadDotEnv() {
+function preloadDotEnv(): Record<string, string> {
   const dotenvPath = walkBack(process.cwd(), '.env');
   if (dotenvPath) {
-    dotenv.config({ path: dotenvPath });
+    const outcome = dotenv.config({ path: dotenvPath });
+    if (outcome.error) {
+      throw outcome.error;
+    }
+    if (outcome.parsed) {
+      debug(`Parsed ${Object.keys(outcome.parsed).length} environment variables from ${dotenvPath}`);
+      return outcome.parsed;
+    }
   }
+  return {};
 }
 
 function initialize(options?: IProviderOptions) {
   options = options || {};
-  if (!options.skipDotEnv) {
-    preloadDotEnv();
+  // By capturing the values, we can override without relying on the default dotenv
+  // approach and better log the outcomes.
+  const dotenvValues = !options.skipDotEnv ? preloadDotEnv() : {};
+  if (options.provider) {
+    debug(`options.provider was provided: ${options.provider}. Skipping any .env values.`);
   }
-  const provider = options.provider || processEnvironmentProvider();
+
+  const envProviderOptions = { overrideValues: {} };
+  const provider = options.provider || processEnvironmentProvider(envProviderOptions);
+  const preferDotEnvChoice = provider.get(DotEnvOverridesProcessKey) === '1';
+  if (preferDotEnvChoice) {
+    // Yes, this is setting the value on the options object above and so is expecting
+    // that the provider implementation is not destructing the options.
+    envProviderOptions.overrideValues = dotenvValues;
+    debug(
+      `The ${DotEnvOverridesProcessKey} environment variable was set to 1. Preferring .env file over process.env values.`
+    );
+  }
   let environmentInstances = null;
   const applicationRoot = options.applicationRoot || appRoot;
   const applicationName = (options.applicationName ||

--- a/lib/github/composite.ts
+++ b/lib/github/composite.ts
@@ -159,7 +159,7 @@ export class CompositeIntelligentEngine extends IntelligentEngine {
     } else {
       if (!metadata) {
         let reason = metadata === undefined ? 'undefined' : 'unknown';
-        if (metadata === false) {
+        if ((metadata as unknown as boolean) === false) {
           reason = 'false value';
         } else if (metadata === null) {
           reason = 'null value';

--- a/middleware/business/organization.ts
+++ b/middleware/business/organization.ts
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { ReposAppRequest } from '../../interfaces/web';
+import { jsonError } from '../jsonError';
+
+export enum OrganizationManagementType {
+  Managed = 'managed',
+  Unmanaged = 'unmanaged',
+}
+
+export interface IReposAppRequestWithOrganizationManagementType extends ReposAppRequest {
+  organizationManagementType: OrganizationManagementType;
+  organizationName: string;
+  organizationProfile: any;
+}
+
+export function getOrganizationManagementType(req: IReposAppRequestWithOrganizationManagementType) {
+  return req.organizationManagementType;
+}
+
+export function blockIfUnmanagedOrganization(req: IReposAppRequestWithOrganizationManagementType, res, next) {
+  const managementType = getOrganizationManagementType(req);
+  switch (managementType) {
+    case OrganizationManagementType.Unmanaged:
+      return next(jsonError('unmanaged organization', 404));
+    case OrganizationManagementType.Managed:
+      return next();
+    default:
+      return next(jsonError('unknown organization management type', 500));
+  }
+}

--- a/middleware/react.ts
+++ b/middleware/react.ts
@@ -38,6 +38,7 @@ type ContentOptions = {
 
 type FlightingOptions = ContentOptions & {
   enabled: boolean;
+  divertEveryone: boolean;
   staticFlightIds?: Set<string>;
   flightName: string;
 };
@@ -58,8 +59,9 @@ export function injectReactClient() {
     const flightAvailable = flightingOptions.enabled && flightingOptions.html;
     const flightName = flightAvailable ? flightingOptions.flightName : null;
     const userFlighted =
-      activeContext?.corporateIdentity?.id &&
-      flightingOptions.staticFlightIds?.has(activeContext.corporateIdentity.id);
+      flightingOptions.divertEveryone === true ||
+      (activeContext?.corporateIdentity?.id &&
+        flightingOptions.staticFlightIds?.has(activeContext.corporateIdentity.id));
     const userFlightOverride =
       req.query.flight === '0' || req.query.flight === '1' ? req.query.flight : undefined;
     let inFlight = flightAvailable && (userFlighted || req.query.flight === '1');
@@ -147,6 +149,7 @@ function evaluateFlightConditions(req: ReposAppRequest): FlightingOptions {
     const flights = options.package.flights;
     options.flightName = (flights || {})[branchName] || 'unknown';
     options.enabled = true;
+    options.divertEveryone = config.client.flighting.divertEveryone;
     options.staticFlightIds = new Set<string>(
       Array.isArray(config.client.flighting.corporateIds)
         ? config.client.flighting.corporateIds

--- a/pg.sql
+++ b/pg.sql
@@ -104,6 +104,15 @@ CREATE TABLE IF NOT EXISTS organizationsettings (
 CREATE INDEX IF NOT EXISTS organizationsettings_active ON organizationsettings ((metadata->>'active'));
 CREATE INDEX IF NOT EXISTS organizationsettings_organizationid ON organizationsettings ((metadata->>'organizationid'));
 
+CREATE TABLE IF NOT EXISTS organizationannotations (
+  entitytype text,
+  entityid text,
+  metadata jsonb,
+  PRIMARY KEY(entitytype, entityid)
+);
+
+CREATE INDEX IF NOT EXISTS organizationannotations_organizationid ON organizationannotations ((metadata->>'organizationid'));
+
 CREATE TABLE IF NOT EXISTS usersettings (
   entitytype text,
   entityid text,

--- a/utils.ts
+++ b/utils.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
 import zlib from 'zlib';
+
 import { ReposAppRequest, IAppSession, IReposError, SiteConfiguration } from './interfaces';
 import { getProviders } from './transitional';
 


### PR DESCRIPTION
Integrates multiple changes from an internal fork to the open project:

- Strongly typing basic organization properties and flags
- Specialized app purposes
- Organization annotations
- Repo unarchive
- Configuration resolver supports dates
- Configuration resolver supporting above-root .env over env vars for Codespaces
- Initialization routine adds support for an optional company-specific secondary stage
- Supports flighting a second React frontend for specific or all users
- Most basic organization APIs support managed and unmanaged orgs for org details

