### PR TITLE
More consistent static organization configuration support

### DIFF
--- a/.ossdev/environment/env/table.jsonc
+++ b/.ossdev/environment/env/table.jsonc
@@ -1,10 +1,12 @@
+// Table storage for entities and links
+
 // Environment mapping file. Similar to a ".env" file, this contains a standard set
 // of environment variables that are used by the environment. However, the
 // "painless config as code" system under this is able to use Azure KeyVault to
 // retrieve secrets at runtime, making dev environment bootstrapping and deployment
 // quite a bit easier.
 {
-  "ENVIRONMENT_NAME": "Local Development (OSS)",
+  "ENVIRONMENT_NAME": "Local Development with Tables (OSS)",
   //
   // Operations, support e-mail addresses. In development you may want to override these.
   "PORTAL_ADMIN_EMAIL": "keyvault://cafe.vault.azure.net/secrets/email-contact",
@@ -25,14 +27,8 @@
   // Email: you MUST override this in your .env or env vars. Avoids sending prod-style email.
   "MAIL_OVERRIDE_RECIPIENT": "developer@localhost",
   //
-  // Source of truth database
-  "REPOS_LINKS_PROVIDER_NAME": "postgres",
-  "REPOS_GITHUB_APPROVALS_PROVIDER_NAME": "postgres",
-  "REPOS_POSTGRES_DATABASE": "keyvault://database@cafe.vault.azure.net/secrets/postgres",
-  "REPOS_POSTGRES_HOST": "keyvault://hostname@cafe.vault.azure.net/secrets/postgres",
-  "REPOS_POSTGRES_USER": "keyvault://username@cafe.vault.azure.net/secrets/postgres",
-  "REPOS_POSTGRES_PASSWORD": "keyvault://cafe.vault.azure.net/secrets/postgres",
-  "REPOS_POSTGRES_LINKS_TABLE_NAME": "links",
+  "REPOS_LINKS_PROVIDER_NAME": "table",
+
   //
   // Cookies
   "SESSION_NAME": "session",

--- a/.ossdev/environment/github.organizations/development.jsonc
+++ b/.ossdev/environment/github.organizations/development.jsonc
@@ -1,0 +1,13 @@
+[
+  {
+    // A very simple org, not an enterprise cloud product.
+    "name": "OpenContoso",
+
+    // To simplify smaller installations, this indicates that at startup, all
+    // configured modern GItHub Apps should iterate through their installations
+    // to identify the installation ID and other information about this org.
+    // This will also backfill the organization ID value in the config.
+    "startupDiscover": true,
+    "active": true
+  }
+]

--- a/.ossdev/environment/github.organizations/opensource.jsonc
+++ b/.ossdev/environment/github.organizations/opensource.jsonc
@@ -1,0 +1,13 @@
+[
+  {
+    // A very simple org, not an enterprise cloud product.
+    "name": "OpenContoso",
+
+    // To simplify smaller installations, this indicates that at startup, all
+    // configured modern GItHub Apps should iterate through their installations
+    // to identify the installation ID and other information about this org.
+    // This will also backfill the organization ID value in the config.
+    "startupDiscover": true,
+    "active": true
+  }
+]

--- a/.ossdev/environment/github.organizations/table.jsonc
+++ b/.ossdev/environment/github.organizations/table.jsonc
@@ -1,0 +1,13 @@
+[
+  {
+    // A very simple org, not an enterprise cloud product.
+    "name": "OpenContoso",
+
+    // To simplify smaller installations, this indicates that at startup, all
+    // configured modern GItHub Apps should iterate through their installations
+    // to identify the installation ID and other information about this org.
+    // This will also backfill the organization ID value in the config.
+    "startupDiscover": true,
+    "active": true
+  }
+]

--- a/business/operations/core.ts
+++ b/business/operations/core.ts
@@ -20,6 +20,7 @@ import {
   throwIfNotCapable,
   IOperationsCentralOperationsToken,
   IAuthorizationHeaderValue,
+  SiteConfiguration,
 } from '../../interfaces';
 import { RestLibrary } from '../../lib/github';
 import { CreateError } from '../../transitional';
@@ -233,7 +234,7 @@ export abstract class OperationsCore
     return this._providers;
   }
 
-  get config(): any {
+  get config(): SiteConfiguration {
     return this.providers.config;
   }
 

--- a/business/operations/index.ts
+++ b/business/operations/index.ts
@@ -215,12 +215,12 @@ export class Operations
           (d.hasFeature(OrganizationFeature.Ignore) && d.hasFeature(OrganizationFeature.Invisible))
       );
       this._organizationSettings = unignoredDynamicOrganizations;
-      this._dynamicOrganizationIds = new Set(
-        unignoredDynamicOrganizations.map((org) => Number(org.organizationId))
-      );
       // Discover of installations at startup
       const toDiscover = organizationSettings.filter((os) => os.hasFeature('startupDiscover'));
       await this.startupDiscoverInstallations(toDiscover);
+      this._dynamicOrganizationIds = new Set(
+        unignoredDynamicOrganizations.map((org) => Number(org.organizationId))
+      );
     }
     if (this._organizationSettings && organizationSettingsProvider) {
       DynamicRestartCheckHandle = setInterval(
@@ -388,19 +388,19 @@ export class Operations
       const centralOperationsToken = this.config.github.operations.centralOperationsToken;
       for (let i = 0; i < names.length; i++) {
         const name = names[i];
-        let dynamicSettings: OrganizationSetting = null;
-        this._organizationSettings.map((dos) => {
+        let settings: OrganizationSetting = null;
+        for (const dos of this._organizationSettings) {
           if (
             dos.active &&
             dos.organizationName.toLowerCase() === name.toLowerCase() &&
             !dos.hasFeature(OrganizationFeature.Invisible)
           ) {
-            dynamicSettings = dos;
+            settings = dos;
           }
-        });
+        }
         const organization = this.createOrganization(
           name,
-          dynamicSettings,
+          settings,
           centralOperationsToken,
           GitHubAppAuthenticationType.BestAvailable
         );

--- a/business/operations/index.ts
+++ b/business/operations/index.ts
@@ -43,6 +43,7 @@ import {
   ICrossOrganizationMembershipByOrganization,
   ICrossOrganizationTeamMembership,
   IGetAuthorizationHeader,
+  IGitHubAppInstallation,
   IMapPlusMetaCost,
   IOperationsCentralOperationsToken,
   IOperationsHierarchy,
@@ -58,14 +59,15 @@ import {
   IPurposefulGetAuthorizationHeader,
   ISupportedLinkTypeOutcome,
   IUnlinkMailStatus,
+  NoCacheNoBackground,
   SupportedLinkType,
-  throwIfNotGitHubCapable,
   UnlinkPurpose,
 } from '../../interfaces';
 import { CreateError, ErrorHelper } from '../../transitional';
 import { Team } from '../team';
 import { IRepositoryMetadataProvider } from '../../entities/repositoryMetadata/repositoryMetadataProvider';
 import { isAuthorizedSystemAdministrator } from './administration';
+import type { ConfigGitHubOrganizationsSpecializedList } from '../../config/github.organizations.types';
 
 export * from './core';
 
@@ -123,7 +125,7 @@ export class Operations
   private _organizationNamesWithAuthorizationHeaders: Map<string, IPurposefulGetAuthorizationHeader>;
   private _defaultPageSize: number;
   private _organizationIds: Map<number, Organization>;
-  private _dynamicOrganizationSettings: OrganizationSetting[];
+  private _organizationSettings: OrganizationSetting[];
   private _dynamicOrganizationIds: Set<number>;
   private _portalSudo: IPortalSudo;
   private _tokenManager: GitHubTokenManager;
@@ -181,7 +183,7 @@ export class Operations
     });
     GitHubTokenManager.RegisterManagerForOperations(this, this._tokenManager);
     this._dynamicOrganizationIds = new Set();
-    this._dynamicOrganizationSettings = [];
+    this._organizationSettings = [];
   }
 
   protected get tokenManager() {
@@ -195,23 +197,32 @@ export class Operations
   async initialize() {
     await super.initialize();
     const hasModernGitHubApps = this.config.github && this.config.github.app;
-    // const hasConfiguredOrganizations = this.config.github.organizations && this.config.github.organizations.length;
+    const staticConfiguredOrganizations = this.config?.github?.organizations || [];
     const organizationSettingsProvider = this.providers.organizationSettingsProvider;
     if (hasModernGitHubApps && organizationSettingsProvider) {
-      const dynamicOrganizations = (await organizationSettingsProvider.queryAllOrganizations()).filter(
-        (dynamicOrg) => dynamicOrg.active === true
+      const staticOrganizationSettings = staticConfiguredOrganizations.map((staticOrg) =>
+        OrganizationSetting.CreateFromStaticSettings(staticOrg)
       );
-      const unignoredDynamicOrganizations = dynamicOrganizations.filter(
+      const organizationSettings = [
+        ...(await organizationSettingsProvider.queryAllOrganizations()).filter(
+          (dynamicOrg) => dynamicOrg.active === true
+        ),
+        ...staticOrganizationSettings,
+      ];
+      const unignoredDynamicOrganizations = organizationSettings.filter(
         (d) =>
           !d.hasFeature(OrganizationFeature.Ignore) ||
           (d.hasFeature(OrganizationFeature.Ignore) && d.hasFeature(OrganizationFeature.Invisible))
       );
-      this._dynamicOrganizationSettings = unignoredDynamicOrganizations;
+      this._organizationSettings = unignoredDynamicOrganizations;
       this._dynamicOrganizationIds = new Set(
         unignoredDynamicOrganizations.map((org) => Number(org.organizationId))
       );
+      // Discover of installations at startup
+      const toDiscover = organizationSettings.filter((os) => os.hasFeature('startupDiscover'));
+      await this.startupDiscoverInstallations(toDiscover);
     }
-    if (this._dynamicOrganizationSettings && organizationSettingsProvider) {
+    if (this._organizationSettings && organizationSettingsProvider) {
       DynamicRestartCheckHandle = setInterval(
         restartAfterDynamicConfigurationUpdate.bind(
           null,
@@ -230,6 +241,64 @@ export class Operations
     return this;
   }
 
+  async startupDiscoverInstallations(settings: OrganizationSetting[], alwaysDiscover?: boolean) {
+    const discovered = new Map<string, IGitHubAppInstallation[]>();
+    try {
+      if (!alwaysDiscover && settings.length === 0) {
+        return discovered;
+      }
+      const orgNames = settings.map((s) => s.organizationName.toLowerCase());
+      const orgNamesWithoutIds = settings
+        .filter((s) => !s.organizationId)
+        .map((s) => s.organizationName.toLowerCase());
+      // Get the apps
+      const apps = this.getApplications();
+      for (const app of apps) {
+        try {
+          const installs = await app.getInstallations(NoCacheNoBackground);
+          for (const install of installs) {
+            // Backfill ID
+            if (orgNamesWithoutIds.includes(install.account.login.toLowerCase())) {
+              const org = settings.find(
+                (s) => s.organizationName.toLowerCase() === install.account.login.toLowerCase()
+              );
+              if (org) {
+                org.organizationId = install.account.id;
+              }
+            }
+            // Installation
+            let foundOrg = false;
+            if (orgNames.includes(install.account.login.toLowerCase())) {
+              const org = settings.find(
+                (s) => s.organizationName.toLowerCase() === install.account.login.toLowerCase()
+              );
+              if (org) {
+                foundOrg = true;
+                org.installations.push({
+                  installationId: install.id,
+                  appId: app.id,
+                });
+              }
+            }
+            if (!foundOrg) {
+              let installs = discovered.get(install.account.login.toLowerCase());
+              if (!installs) {
+                installs = [];
+                discovered.set(install.account.login.toLowerCase(), installs);
+              }
+              installs.push(install);
+            }
+          }
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    } catch (error) {
+      console.dir(error);
+    }
+    return discovered;
+  }
+
   get previewMediaTypes() {
     return {
       repository: {
@@ -244,18 +313,11 @@ export class Operations
     if (!this._organizationNames) {
       const names = [];
       const processed = new Set<string>();
-      for (const dynamic of this._dynamicOrganizationSettings) {
+      for (const dynamic of this._organizationSettings) {
         if (!dynamic.hasFeature(OrganizationFeature.Invisible)) {
           const lowercase = dynamic.organizationName.toLowerCase();
           processed.add(lowercase);
           names.push(lowercase);
-        }
-      }
-      for (let i = 0; i < this.config.github.organizations.length; i++) {
-        const lowercase = this.config.github.organizations[i].name.toLowerCase();
-        if (!processed.has(lowercase)) {
-          names.push(lowercase);
-          processed.add(lowercase);
         }
       }
       this._organizationNames = names.sort(sortByCaseInsensitive);
@@ -263,38 +325,19 @@ export class Operations
     return this._organizationNames;
   }
 
+  getOrganizationSettings(name: string) {
+    return this._organizationSettings.find((s) => s.organizationName.toLowerCase() === name.toLowerCase());
+  }
+
   getOrganizationIds(): number[] {
     if (!this._organizationIds) {
-      const organizations = this.organizations;
       this._organizationIds = new Map();
-      this._dynamicOrganizationSettings.map((entry) => {
+      this._organizationSettings.map((entry) => {
         if (entry.active && !entry.hasFeature(OrganizationFeature.Invisible)) {
           const org = this.getOrganization(entry.organizationName.toLowerCase());
           this._organizationIds.set(Number(entry.organizationId), org);
         }
       });
-      // This check only runs on _static_ configuration entries, since adopted
-      // GitHub App organizations must always have an organization ID.
-      for (let i = 0; i < this.config.github.organizations.length; i++) {
-        const organizationConfiguration = this.config.github.organizations[i];
-        const organization = organizations.get(organizationConfiguration.name.toLowerCase());
-        if (!organization) {
-          throw new Error(`Missing organization configuration ${organizationConfiguration.name}`);
-        }
-        if (!organizationConfiguration.id) {
-          if (throwIfOrganizationIdsMissing) {
-            throw new Error(
-              `Organization ${organization.name} is not configured with an 'id' which can lead to issues if the organization is renamed. throwIfOrganizationIdsMissing is true: id is required`
-            );
-          } else {
-            console.warn(
-              `Organization ${organization.name} is not configured with an 'id' which can lead to issues if the organization is renamed.`
-            );
-          }
-        } else if (!this._organizationIds.has(organizationConfiguration.id)) {
-          this._organizationIds.set(organizationConfiguration.id, organization);
-        }
-      }
     }
     return Array.from(this._organizationIds.keys());
   }
@@ -306,32 +349,10 @@ export class Operations
     appAuthenticationType: GitHubAppAuthenticationType
   ): Organization {
     name = name.toLowerCase();
-    let ownerToken = null;
-    if (!settings) {
-      let staticSettings = null;
-      const group = this.config.github.organizations;
-      for (let i = 0; i < group.length; i++) {
-        if (group[i].name && group[i].name.toLowerCase() === name) {
-          const staticOrganizationSettings = group[i];
-          if (staticOrganizationSettings.ownerToken) {
-            ownerToken = staticOrganizationSettings.ownerToken;
-          }
-          staticSettings = staticOrganizationSettings;
-          break;
-        }
-      }
-      try {
-        settings = OrganizationSetting.CreateFromStaticSettings(staticSettings);
-        settings.active = true;
-      } catch (translateStaticSettingsError) {
-        throw new Error(
-          `This application is not able to translate the static configuration for the ${name} organization. Specific error: ${translateStaticSettingsError.message}`
-        );
-      }
-    }
     if (!settings) {
       throw new Error(`This application is not configured for the ${name} organization`);
     }
+    const ownerToken = settings.getOwnerToken();
     const hasDynamicSettings =
       this._dynamicOrganizationIds &&
       settings.organizationId &&
@@ -368,7 +389,7 @@ export class Operations
       for (let i = 0; i < names.length; i++) {
         const name = names[i];
         let dynamicSettings: OrganizationSetting = null;
-        this._dynamicOrganizationSettings.map((dos) => {
+        this._organizationSettings.map((dos) => {
           if (
             dos.active &&
             dos.organizationName.toLowerCase() === name.toLowerCase() &&
@@ -394,15 +415,17 @@ export class Operations
     // An 'alternate' organization is one whose static settings come from a
     // different location within the github.organizations config file.
     const lowercase = name.toLowerCase();
-    const list = this.config.github.organizations[alternativeType];
-    if (list) {
+    const list = this.config.github.organizations[
+      alternativeType
+    ] as any as ConfigGitHubOrganizationsSpecializedList;
+    if (list?.length) {
       for (let i = 0; i < list.length; i++) {
         const settings = list[i];
         if (settings && settings.name && settings.name.toLowerCase() === lowercase) {
           const centralOperationsToken = this.config.github.operations.centralOperationsToken;
           return this.createOrganization(
             lowercase,
-            settings,
+            OrganizationSetting.CreateFromStaticSettings(settings),
             centralOperationsToken,
             GitHubAppAuthenticationType.BestAvailable
           );
@@ -441,7 +464,7 @@ export class Operations
       return this._invisibleOrganizations.get(lowercase);
     }
     let dynamicSettings: OrganizationSetting = null;
-    this._dynamicOrganizationSettings.map((dos) => {
+    this._organizationSettings.map((dos) => {
       if (
         dos.active &&
         dos.organizationName.toLowerCase() === lowercase &&
@@ -550,18 +573,10 @@ export class Operations
     if (!this._organizationOriginalNames) {
       const names: string[] = [];
       const visited = new Set<string>();
-      for (const entry of this._dynamicOrganizationSettings) {
+      for (const entry of this._organizationSettings) {
         if (entry.active && !entry.hasFeature(OrganizationFeature.Invisible)) {
           names.push(entry.organizationName);
           const lowercase = entry.organizationName.toLowerCase();
-          visited.add(lowercase);
-        }
-      }
-      for (let i = 0; i < this.config.github.organizations.length; i++) {
-        const original = this.config.github.organizations[i].name;
-        const lowercase = original.toLowerCase();
-        if (!visited.has(lowercase)) {
-          names.push(original);
           visited.add(lowercase);
         }
       }
@@ -586,7 +601,7 @@ export class Operations
     if (!this._organizationNamesWithAuthorizationHeaders) {
       const tokens = new Map<string, IPurposefulGetAuthorizationHeader>();
       const visited = new Set<string>();
-      for (const entry of this._dynamicOrganizationSettings) {
+      for (const entry of this._organizationSettings) {
         const lowercase = entry.organizationName.toLowerCase();
         if (entry.active && !visited.has(lowercase) && !entry.hasFeature(OrganizationFeature.Invisible)) {
           visited.add(lowercase);
@@ -594,16 +609,6 @@ export class Operations
           const token = orgInstance.getAuthorizationHeader();
           tokens.set(lowercase, token);
         }
-      }
-      for (let i = 0; i < this.config.github.organizations.length; i++) {
-        const name = this.config.github.organizations[i].name.toLowerCase();
-        if (visited.has(name)) {
-          continue;
-        }
-        visited.add(name);
-        const orgInstance = this.getOrganization(name);
-        const token = orgInstance.getAuthorizationHeader();
-        tokens.set(name, token);
       }
       this._organizationNamesWithAuthorizationHeaders = tokens;
     }
@@ -769,7 +774,7 @@ export class Operations
   }
 
   getInfrastructureNotificationsMail(): string {
-    return this.config.notifications.infrastructureNotificationsMail || this.getOperationsMailAddress();
+    return this.config.brand.infrastructureNotificationsMail || this.getOperationsMailAddress();
   }
 
   getLinksNotificationMailAddress(): string {
@@ -1212,7 +1217,7 @@ export class Operations
   }
 
   allowUndoSystem() {
-    return this.config?.features?.features.allowUndoSystem === true;
+    return this.config?.features?.allowUndoSystem === true;
   }
 
   // Eventually link/unlink should move from context into operations here to centralize more than just the events
@@ -1423,7 +1428,7 @@ export function getCentralOperationsAuthorizationHeader(self: Operations): IPurp
         source: 'central operations token',
       };
     };
-  } else if (s.getOrganizations.length === 0) {
+  } else if (s.getOrganizations().length === 0) {
     throw new Error('No central operations token nor any organizations configured.');
   }
   // Fallback to the first configured organization as a convenience

--- a/config/brand.types.ts
+++ b/config/brand.types.ts
@@ -17,5 +17,5 @@ export type ConfigBrand = {
   operationsMail: string;
   forkApprovalMail: string;
   electionMail: string;
-  infrastructureNotificationMail: string;
+  infrastructureNotificationsMail: string;
 };

--- a/config/github.organizations.js
+++ b/config/github.organizations.js
@@ -14,6 +14,7 @@ const path = require('path');
 const organizationsFileVariableName = 'GITHUB_ORGANIZATIONS_FILE';
 const organizationsEnvironmentVariableName = 'GITHUB_ORGANIZATIONS_ENVIRONMENT_NAME';
 const organizationsEnvironmentTypeVariableName = 'GITHUB_ORGANIZATIONS_ENVIRONMENT_TYPE_NAME';
+const painlessConfigEnvironmentVariableName = 'CONFIGURATION_ENVIRONMENT';
 
 const defaultEnvironmentTypeName = 'github.organizations';
 
@@ -53,7 +54,9 @@ module.exports = (graphApi) => {
   );
   const defaultTemplates = arrayFromString(environmentProvider.get('GITHUB_ORGANIZATIONS_DEFAULT_TEMPLATES'));
   const organizationsFile = environmentProvider.get(organizationsFileVariableName);
-  const organizationsEnvironmentName = environmentProvider.get(organizationsEnvironmentVariableName);
+  const organizationsEnvironmentName =
+    environmentProvider.get(organizationsEnvironmentVariableName) ||
+    environmentProvider.get(painlessConfigEnvironmentVariableName);
   const organizationsEnvironmentType =
     environmentProvider.get(organizationsEnvironmentTypeVariableName) || defaultEnvironmentTypeName;
   if (organizationsFile && organizationsEnvironmentName) {

--- a/config/github.organizations.types.ts
+++ b/config/github.organizations.types.ts
@@ -18,9 +18,22 @@ export type ConfigGitHubOrganization = {
   preventLargeTeamPermissions: boolean;
   teamAllReposRead: string; // | number
   teamAllReposWrite: string; // | number
+  teamAllReposAdmin: string;
+  teamSudoers: string;
   templates: string[];
   onboarding: boolean;
   ignore: boolean;
+  active?: boolean;
+  hidden?: boolean;
+  locked?: boolean;
+  createReposDirect?: boolean;
+  startupDiscover?: boolean;
+  externalMembersPermitted?: boolean;
+  privateEngineering?: boolean;
+  noPrivateEngineeringNags?: boolean;
+  legalEntities?: string[];
+  __special__note__?: string;
+  __special_note___?: string;
 };
 
 export type ConfigGitHubOrganizationsSpecializedList = ConfigGitHubOrganization[] & {

--- a/entities/auditLogRecord/auditLogRecord.ts
+++ b/entities/auditLogRecord/auditLogRecord.ts
@@ -21,7 +21,7 @@ import {
 import { IDictionary } from '../../interfaces';
 import { AuditLogSource } from '.';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = Type;
 
@@ -146,63 +146,12 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, recordId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.recordSource, Field.recordSource.toLowerCase()],
-    [Field.action, Field.action.toLowerCase()],
-    [Field.actorId, Field.actorId.toLowerCase()],
-    [Field.actorUsername, Field.actorUsername.toLowerCase()],
-    [Field.additionalData, Field.additionalData.toLowerCase()],
-    [Field.actorCorporateUsername, Field.actorCorporateUsername.toLowerCase()],
-    [Field.actorCorporateId, Field.actorCorporateId.toLowerCase()],
-    [Field.teamId, Field.teamId.toLowerCase()],
-    [Field.teamName, Field.teamName.toLowerCase()],
-    [Field.incomingId, Field.incomingId.toLowerCase()],
-    [Field.incomingUsername, Field.incomingUsername.toLowerCase()],
-    [Field.inserted, Field.inserted.toLowerCase()],
-    [Field.created, Field.created.toLowerCase()],
-    [Field.repositoryId, Field.repositoryId.toLowerCase()],
-    [Field.repositoryName, Field.repositoryName.toLowerCase()],
-    [Field.organizationId, Field.organizationId.toLowerCase()],
-    [Field.organizationName, Field.organizationName.toLowerCase()],
-    [Field.userId, Field.userId.toLowerCase()],
-    [Field.userUsername, Field.userUsername.toLowerCase()],
-    [Field.userCorporateId, Field.userCorporateId.toLowerCase()],
-    [Field.userCorporateUsername, Field.userCorporateUsername.toLowerCase()],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [recordId]);
 
 PostgresConfiguration.SetDefaultTableName(type, 'auditlog');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'auditlogrecord');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.recordSource, Field.recordSource.toLowerCase()],
-    [Field.action, Field.action.toLowerCase()],
-    [Field.actorId, Field.actorId.toLowerCase()],
-    [Field.actorUsername, Field.actorUsername.toLowerCase()],
-    [Field.actorCorporateUsername, Field.actorCorporateUsername.toLowerCase()],
-    [Field.actorCorporateId, Field.actorCorporateId.toLowerCase()],
-    [Field.additionalData, Field.additionalData.toLowerCase()],
-    [Field.teamId, Field.teamId.toLowerCase()],
-    [Field.teamName, Field.teamName.toLowerCase()],
-    [Field.incomingId, Field.incomingId.toLowerCase()],
-    [Field.incomingUsername, Field.incomingUsername.toLowerCase()],
-    [Field.inserted, Field.inserted.toLowerCase()],
-    [Field.created, Field.created.toLowerCase()],
-    [Field.repositoryId, Field.repositoryId.toLowerCase()],
-    [Field.repositoryName, Field.repositoryName.toLowerCase()],
-    [Field.organizationId, Field.organizationId.toLowerCase()],
-    [Field.organizationName, Field.organizationName.toLowerCase()],
-    [Field.userId, Field.userId.toLowerCase()],
-    [Field.userUsername, Field.userUsername.toLowerCase()],
-    [Field.userCorporateId, Field.userCorporateId.toLowerCase()],
-    [Field.userCorporateUsername, Field.userCorporateUsername.toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [recordId]);
 
 EntityMetadataMappings.Register(

--- a/entities/organizationAnnotation.ts
+++ b/entities/organizationAnnotation.ts
@@ -31,6 +31,7 @@ import {
 import { PostgresSettings, PostgresConfiguration } from '../lib/entityMetadataProvider/postgres';
 import { IDictionary } from '../interfaces';
 import { CreateError, ErrorHelper } from '../transitional';
+import { MemoryConfiguration, TableConfiguration } from '../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('OrganizationAnnotation');
 const thisProviderType = type;
@@ -152,7 +153,13 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, organizationId);
 
-// NOTE: No memory mapping for this type that is only in Postgres
+const defaultTableName = defaultPostgresTableName;
+
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 
 EntityMetadataMappings.Register(
   type,

--- a/entities/organizationMemberCache/organizationMemberCache.ts
+++ b/entities/organizationMemberCache/organizationMemberCache.ts
@@ -18,7 +18,7 @@ import {
   PostgresSettings,
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = new EntityMetadataType('OrganizationMemberCache');
 
@@ -113,17 +113,7 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, Field.uniqueId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.cacheUpdated, 'cached'],
-    [Field.organizationId, 'orgid'],
-    [Field.uniqueId, 'unique'],
-    [Field.userId, 'userid'],
-    [Field.role, 'role'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 
 PostgresConfiguration.SetDefaultTableName(type, 'organizationmembercache');
@@ -132,16 +122,7 @@ EntityMetadataMappings.Register(
   PostgresSettings.PostgresDefaultTypeColumnName,
   'organizationmembercache'
 );
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-    [Field.uniqueId, (Field.uniqueId as string).toLowerCase()],
-    [Field.userId, (Field.userId as string).toLowerCase()],
-    [Field.role, (Field.role as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);
 
 EntityMetadataMappings.Register(

--- a/entities/organizationSettings/organizationSetting.ts
+++ b/entities/organizationSettings/organizationSetting.ts
@@ -11,12 +11,17 @@ import {
   MetadataMappingDefinition,
 } from '../../lib/entityMetadataProvider/declarations';
 import { Type } from './type';
+import { PostgresGetAllEntities } from '../../lib/entityMetadataProvider/postgres';
 import {
-  PostgresGetAllEntities,
+  MemoryConfiguration,
+  MemorySettings,
   PostgresSettings,
   PostgresConfiguration,
-} from '../../lib/entityMetadataProvider/postgres';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+  TableConfiguration,
+  TableSettings,
+} from '../../lib/entityMetadataProvider';
+import { ConfigGitHubOrganization } from '../../config/github.organizations.types';
+import { odata, TableEntityQueryOptions } from '@azure/data-tables';
 
 export interface IBasicGitHubAppInstallation {
   appId: number;
@@ -50,6 +55,8 @@ export interface ISpecialTeam {
 
 const type = Type;
 
+const tableName = 'organizationsettings';
+
 interface IOrganizationSettingProperties {
   // THIS IS THE PRIMARY ID: organizationId: any;
   organizationName: any;
@@ -74,6 +81,7 @@ interface IOrganizationSettingProperties {
 }
 
 const organizationId = 'organizationId';
+const primaryKeyFieldName = organizationId;
 
 const Field: IOrganizationSettingProperties = {
   // organizationId: 'organizationId',
@@ -97,6 +105,8 @@ const Field: IOrganizationSettingProperties = {
 const fieldNames = Object.getOwnPropertyNames(Field);
 
 export class OrganizationSetting implements IOrganizationSettingProperties {
+  #ownerToken: string;
+
   organizationId: number;
   organizationName: string;
 
@@ -137,11 +147,17 @@ export class OrganizationSetting implements IOrganizationSettingProperties {
     return this.properties[key];
   }
 
-  static CreateFromStaticSettings(staticSettings: any): OrganizationSetting {
-    const clone = { ...staticSettings };
-    delete clone.ownerToken;
+  getOwnerToken() {
+    return this.#ownerToken;
+  }
 
+  static CreateFromStaticSettings(staticSettings: ConfigGitHubOrganization): OrganizationSetting {
+    const clone = { ...staticSettings };
     const settings = new OrganizationSetting();
+    if (clone.ownerToken) {
+      settings.#ownerToken = clone.ownerToken;
+      delete clone.ownerToken;
+    }
 
     settings.organizationId = clone.id;
     settings.organizationName = clone.name;
@@ -156,6 +172,15 @@ export class OrganizationSetting implements IOrganizationSettingProperties {
     delete clone.templates;
 
     // Feature flags
+    if (clone.active !== undefined) {
+      settings.active = clone.active;
+    }
+    delete clone.active;
+
+    if (clone.startupDiscover) {
+      settings.features.push('startupDiscover');
+    }
+    delete clone.startupDiscover;
 
     if (clone.preventLargeTeamPermissions === true) {
       settings.features.push('preventLargeTeamPermissions');
@@ -338,57 +363,15 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, organizationId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    // [Field.organizationId, 'organizationId'], // the ID field
-    [Field.setupByCorporateDisplayName, (Field.setupByCorporateDisplayName as string).toLowerCase()],
-    [Field.setupByCorporateId, (Field.setupByCorporateId as string).toLowerCase()],
-    [Field.setupByCorporateUsername, (Field.setupByCorporateUsername as string).toLowerCase()],
-    [Field.setupDate, (Field.setupDate as string).toLowerCase()],
-    [Field.active, (Field.active as string).toLowerCase()],
-    [Field.updated, (Field.updated as string).toLowerCase()],
-    [Field.organizationName, (Field.organizationName as string).toLowerCase()],
-    [Field.portalDescription, (Field.portalDescription as string).toLowerCase()],
-    [Field.operationsNotes, (Field.operationsNotes as string).toLowerCase()],
-    [Field.setupByCorporateDisplayName, (Field.setupByCorporateDisplayName as string).toLowerCase()],
-    [Field.installations, (Field.installations as string).toLowerCase()],
-    [Field.features, (Field.features as string).toLowerCase()],
-    [Field.properties, (Field.properties as string).toLowerCase()],
-    [Field.specialTeams, (Field.specialTeams as string).toLowerCase()],
-    [Field.templates, (Field.templates as string).toLowerCase()],
-    [Field.legalEntities, (Field.legalEntities as string).toLowerCase()],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [
   organizationId,
 ]);
 
-PostgresConfiguration.SetDefaultTableName(type, 'organizationsettings');
+PostgresConfiguration.SetDefaultTableName(type, tableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'organizationsetting');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDateColumns, ['updated', 'setupDate']);
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.setupByCorporateDisplayName, (Field.setupByCorporateDisplayName as string).toLowerCase()],
-    [Field.setupByCorporateId, (Field.setupByCorporateId as string).toLowerCase()],
-    [Field.setupByCorporateUsername, (Field.setupByCorporateUsername as string).toLowerCase()],
-    [Field.setupDate, (Field.setupDate as string).toLowerCase()],
-    [Field.active, (Field.active as string).toLowerCase()],
-    [Field.updated, (Field.updated as string).toLowerCase()],
-    [Field.organizationName, (Field.organizationName as string).toLowerCase()],
-    [Field.portalDescription, (Field.portalDescription as string).toLowerCase()],
-    [Field.operationsNotes, (Field.operationsNotes as string).toLowerCase()],
-    [Field.setupByCorporateDisplayName, (Field.setupByCorporateDisplayName as string).toLowerCase()],
-    [Field.installations, (Field.installations as string).toLowerCase()],
-    [Field.features, (Field.features as string).toLowerCase()],
-    [Field.properties, (Field.properties as string).toLowerCase()],
-    [Field.specialTeams, (Field.specialTeams as string).toLowerCase()],
-    [Field.templates, (Field.templates as string).toLowerCase()],
-    [Field.legalEntities, (Field.legalEntities as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [organizationId]);
 
 EntityMetadataMappings.Register(
@@ -428,6 +411,34 @@ EntityMetadataMappings.Register(
         throw new Error(
           `The fixed query type "${query.fixedQueryType}" is not implemented by this provider for the type ${type}`
         );
+    }
+  }
+);
+
+TableConfiguration.SetDefaultTableName(type, tableName);
+TableConfiguration.SetDateColumns(type, [Field.updated]);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetNoPrefixForPartitionKey(type);
+TableConfiguration.SetFixedPartitionKey(type, tableName);
+EntityMetadataMappings.RuntimeValidateMappings(type, TableSettings.TableMapping, fieldNames, [
+  primaryKeyFieldName,
+]);
+
+EntityMetadataMappings.Register(
+  type,
+  TableSettings.TableQueries,
+  (query: IEntityMetadataFixedQuery, fixedPartitionKey: string) => {
+    switch (query.fixedQueryType) {
+      case FixedQueryType.OrganizationSettingsGetAll: {
+        return {
+          filter: odata`PartitionKey eq ${fixedPartitionKey}`,
+        } as TableEntityQueryOptions;
+      }
+      default: {
+        throw new Error(
+          `The fixed query type ${query.fixedQueryType} is not supported currently by this ${type} provider`
+        );
+      }
     }
   }
 );

--- a/entities/repository.ts
+++ b/entities/repository.ts
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+// TODO: is this ever used?
+
 import { IDictionary } from '../interfaces';
 import {
   EntityMetadataBase,

--- a/entities/repositoryCache/repositoryCache.ts
+++ b/entities/repositoryCache/repositoryCache.ts
@@ -17,7 +17,7 @@ import {
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 import { Operations } from '../../business/operations';
 
 const type = new EntityMetadataType('RepositoryCache');
@@ -94,31 +94,14 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, repositoryId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.organizationId, 'orgid'],
-    [Field.repositoryName, 'repoName'],
-    [Field.repositoryDetails, 'repoDetails'],
-    [Field.cacheUpdated, 'cached'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [
   repositoryId,
 ]);
 
 PostgresConfiguration.SetDefaultTableName(type, 'repositorycache');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'repositorycache');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-    [Field.repositoryName, (Field.repositoryName as string).toLowerCase()],
-    [Field.repositoryDetails, (Field.repositoryDetails as string).toLowerCase()],
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [repositoryId]);
 
 EntityMetadataMappings.Register(

--- a/entities/repositoryCache/repositoryCache.ts
+++ b/entities/repositoryCache/repositoryCache.ts
@@ -19,6 +19,7 @@ import {
 import { stringOrNumberAsString } from '../../utils';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 import { Operations } from '../../business/operations';
+import { TableConfiguration } from '../../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('RepositoryCache');
 
@@ -99,7 +100,13 @@ EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMappin
   repositoryId,
 ]);
 
-PostgresConfiguration.SetDefaultTableName(type, 'repositorycache');
+const defaultTableName = 'repositorycache';
+
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'repositorycache');
 PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [repositoryId]);

--- a/entities/repositoryCollaboratorCache/repositoryCollaboratorCache.ts
+++ b/entities/repositoryCollaboratorCache/repositoryCollaboratorCache.ts
@@ -19,7 +19,7 @@ import {
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = new EntityMetadataType('RepositoryCollaboratorCache');
 
@@ -152,24 +152,7 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
   return new RepositoryCollaboratorCacheEntity();
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, Field.uniqueId);
-
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.avatar, 'avatar'],
-    [Field.cacheUpdated, 'cached'],
-    [Field.login, 'login'],
-    [Field.organizationId, 'orgid'],
-    [Field.permission, 'permission'],
-    [Field.repositoryId, 'repoid'],
-    [Field.repositoryName, 'reponame'],
-    [Field.repositoryPrivate, 'repoprivate'],
-    [Field.uniqueId, 'unique'],
-    [Field.userId, 'userid'],
-    [Field.collaboratorType, 'collaboratorType'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 
 PostgresConfiguration.SetDefaultTableName(type, 'repositorycollaboratorcache');
@@ -178,22 +161,7 @@ EntityMetadataMappings.Register(
   PostgresSettings.PostgresDefaultTypeColumnName,
   'repositorycollaboratorcache'
 );
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.avatar, (Field.avatar as string).toLowerCase()],
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-    [Field.login, (Field.login as string).toLowerCase()],
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-    [Field.repositoryName, (Field.repositoryName as string).toLowerCase()], // net new
-    [Field.repositoryPrivate, (Field.repositoryPrivate as string).toLowerCase()], // net new
-    [Field.permission, (Field.permission as string).toLowerCase()],
-    [Field.repositoryId, (Field.repositoryId as string).toLowerCase()],
-    [Field.uniqueId, (Field.uniqueId as string).toLowerCase()],
-    [Field.userId, (Field.userId as string).toLowerCase()],
-    [Field.collaboratorType, (Field.collaboratorType as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);
 
 EntityMetadataMappings.Register(

--- a/entities/repositoryCollaboratorCache/repositoryCollaboratorCache.ts
+++ b/entities/repositoryCollaboratorCache/repositoryCollaboratorCache.ts
@@ -20,6 +20,7 @@ import {
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { TableConfiguration } from '../../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('RepositoryCollaboratorCache');
 
@@ -155,7 +156,13 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnNa
 MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 
-PostgresConfiguration.SetDefaultTableName(type, 'repositorycollaboratorcache');
+const defaultTableName = 'repositorycollaboratorcache';
+
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(
   type,
   PostgresSettings.PostgresDefaultTypeColumnName,

--- a/entities/repositoryMetadata/repositoryMetadata.ts
+++ b/entities/repositoryMetadata/repositoryMetadata.ts
@@ -18,7 +18,7 @@ import {
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
 import { TableSettings } from '../../lib/entityMetadataProvider/table';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 import { odata, TableEntityQueryOptions } from '@azure/data-tables';
 
 const type = Type;
@@ -289,46 +289,7 @@ EntityMetadataMappings.Register(
 EntityMetadataMappings.Register(type, TableSettings.TablePossibleDateColumns, [Field.created]);
 EntityMetadataMappings.RuntimeValidateMappings(type, TableSettings.TableMapping, fieldNames, [repositoryId]);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.createdByThirdPartyId, 'ghid'],
-    [Field.createdByThirdPartyUsername, 'ghu'],
-
-    [Field.createdByCorporateDisplayName, 'name'],
-    [Field.createdByCorporateId, 'aadid'],
-    [Field.createdByCorporateUsername, 'mail'],
-
-    [Field.created, 'requested'],
-
-    [Field.organizationName, 'org'],
-    [Field.organizationId, 'orgid'], // net new
-
-    [Field.repositoryName, 'repoName'],
-    // [repositoryId, azureTableRepositoryIdField], // in table, RowKey is not the repo ID
-
-    [Field.initialTeamPermissions, 'itp'], // special processing case
-    [Field.initialAdministrators, 'initialAdministrators'],
-
-    [Field.initialRepositoryDescription, 'repoDescription'],
-    [Field.initialRepositoryVisibility, 'repoVisibility'],
-    [Field.initialRepositoryHomepage, 'repoHomepage'],
-
-    [Field.initialLicense, 'license'],
-    [Field.initialTemplate, 'template'],
-    [Field.initialGitIgnoreTemplate, 'gitignore_template'],
-    [Field.initialCorrelationId, 'correlationId'],
-
-    [Field.projectType, 'projecttype'],
-    [Field.releaseReviewJustification, 'justification'],
-    [Field.releaseReviewType, 'approvalType'],
-    [Field.releaseReviewUrl, 'approvalUrl'],
-
-    [Field.lockdownState, Field.lockdownState.toLowerCase()],
-    [Field.transferSource, Field.transferSource.toLowerCase()],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [
   repositoryId,
 ]);

--- a/entities/repositoryMetadata/repositoryMetadata.ts
+++ b/entities/repositoryMetadata/repositoryMetadata.ts
@@ -17,7 +17,7 @@ import {
   PostgresSettings,
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
-import { TableSettings } from '../../lib/entityMetadataProvider/table';
+import { TableConfiguration, TableSettings } from '../../lib/entityMetadataProvider/table';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 import { odata, TableEntityQueryOptions } from '@azure/data-tables';
 
@@ -294,47 +294,10 @@ EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMappin
   repositoryId,
 ]);
 
-PostgresConfiguration.SetDefaultTableName(type, 'repositorymetadata');
+const defaultTableName = 'repositorymetadata';
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'repository');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.createdByThirdPartyId, (Field.createdByThirdPartyId as string).toLowerCase()],
-    [Field.createdByThirdPartyUsername, (Field.createdByThirdPartyUsername as string).toLowerCase()],
-
-    [Field.createdByCorporateDisplayName, (Field.createdByCorporateDisplayName as string).toLowerCase()],
-    [Field.createdByCorporateId, (Field.createdByCorporateId as string).toLowerCase()],
-    [Field.createdByCorporateUsername, (Field.createdByCorporateUsername as string).toLowerCase()],
-
-    [Field.created, (Field.created as string).toLowerCase()],
-
-    [Field.organizationName, (Field.organizationName as string).toLowerCase()],
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-
-    [Field.repositoryName, (Field.repositoryName as string).toLowerCase()],
-    // [repositoryId, azureTableRepositoryIdField], // in table, RowKey is not the repo ID
-
-    [Field.initialTeamPermissions, (Field.initialTeamPermissions as string).toLowerCase()], // special processing case
-    [Field.initialAdministrators, (Field.initialAdministrators as string).toLowerCase()], // special processing case
-
-    [Field.initialRepositoryDescription, (Field.initialRepositoryDescription as string).toLowerCase()],
-    [Field.initialRepositoryVisibility, (Field.initialRepositoryVisibility as string).toLowerCase()],
-    [Field.initialRepositoryHomepage, (Field.initialRepositoryHomepage as string).toLowerCase()],
-
-    [Field.initialLicense, (Field.initialLicense as string).toLowerCase()],
-    [Field.initialTemplate, (Field.initialTemplate as string).toLowerCase()],
-    [Field.initialGitIgnoreTemplate, (Field.initialGitIgnoreTemplate as string).toLowerCase()],
-    [Field.initialCorrelationId, (Field.initialCorrelationId as string).toLowerCase()],
-
-    [Field.projectType, (Field.projectType as string).toLowerCase()],
-    [Field.releaseReviewJustification, (Field.releaseReviewJustification as string).toLowerCase()],
-    [Field.releaseReviewType, (Field.releaseReviewType as string).toLowerCase()],
-    [Field.releaseReviewUrl, (Field.releaseReviewUrl as string).toLowerCase()],
-
-    [Field.lockdownState, Field.lockdownState.toLowerCase()],
-    [Field.transferSource, Field.transferSource.toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [repositoryId]);
 
 EntityMetadataMappings.Register(

--- a/entities/repositoryTeamCache/repositoryTeamCache.ts
+++ b/entities/repositoryTeamCache/repositoryTeamCache.ts
@@ -19,7 +19,7 @@ import {
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = new EntityMetadataType('RepositoryTeamCache');
 
@@ -152,37 +152,12 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, Field.uniqueId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.cacheUpdated, 'cached'],
-    [Field.organizationId, 'orgid'],
-    [Field.permission, 'permission'],
-    [Field.repositoryId, 'repoid'],
-    [Field.repositoryPrivate, 'repoprivate'],
-    [Field.uniqueId, 'unique'],
-    [Field.teamId, 'teamId'],
-    [Field.repositoryName, 'repositoryName'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 
 PostgresConfiguration.SetDefaultTableName(type, 'repositoryteamcache');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'repositoryteamcache');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-    [Field.permission, (Field.permission as string).toLowerCase()],
-    [Field.repositoryId, (Field.repositoryId as string).toLowerCase()],
-    [Field.repositoryName, (Field.repositoryName as string).toLowerCase()],
-    [Field.uniqueId, (Field.uniqueId as string).toLowerCase()],
-    [Field.teamId, (Field.teamId as string).toLowerCase()],
-    [Field.repositoryPrivate, (Field.repositoryPrivate as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);
 
 EntityMetadataMappings.Register(

--- a/entities/repositoryTeamCache/repositoryTeamCache.ts
+++ b/entities/repositoryTeamCache/repositoryTeamCache.ts
@@ -20,6 +20,7 @@ import {
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { TableConfiguration } from '../../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('RepositoryTeamCache');
 
@@ -147,6 +148,8 @@ export class RepositoryTeamCacheFixedQueryByRepositoryId implements IEntityMetad
   }
 }
 
+const defaultTableName = 'repositoryteamcache';
+
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiate, () => {
   return new RepositoryTeamCacheEntity();
 });
@@ -155,7 +158,11 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnNa
 MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 
-PostgresConfiguration.SetDefaultTableName(type, 'repositoryteamcache');
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'repositoryteamcache');
 PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);

--- a/entities/teamCache/teamCache.ts
+++ b/entities/teamCache/teamCache.ts
@@ -19,6 +19,7 @@ import {
 import { TeamCacheFixedQueryByOrganizationId, TeamCacheDeleteByOrganizationId } from '.';
 import { stringOrNumberAsString } from '../../utils';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { TableConfiguration } from '../../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('TeamCache');
 
@@ -58,6 +59,8 @@ export class TeamCacheEntity implements ITeamCacheProperties {
   }
 }
 
+const defaultTableName = 'teamcache';
+
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiate, () => {
   return new TeamCacheEntity();
 });
@@ -66,7 +69,11 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnNa
 MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [teamId]);
 
-PostgresConfiguration.SetDefaultTableName(type, 'teamcache');
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'teamcache');
 PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [teamId]);

--- a/entities/teamCache/teamCache.ts
+++ b/entities/teamCache/teamCache.ts
@@ -18,7 +18,7 @@ import {
 } from '../../lib/entityMetadataProvider/postgres';
 import { TeamCacheFixedQueryByOrganizationId, TeamCacheDeleteByOrganizationId } from '.';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = new EntityMetadataType('TeamCache');
 
@@ -63,33 +63,12 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, teamId);
 
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.organizationId, 'orgid'],
-    [Field.teamName, 'teamName'],
-    [Field.teamSlug, 'teamSlug'],
-    [Field.teamDescription, 'teamDescription'],
-    [Field.teamDetails, 'teamDetails'],
-    [Field.cacheUpdated, 'cached'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, [teamId]);
 
 PostgresConfiguration.SetDefaultTableName(type, 'teamcache');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'teamcache');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()], // net new
-    [Field.teamName, (Field.teamName as string).toLowerCase()],
-    [Field.teamSlug, (Field.teamSlug as string).toLowerCase()],
-    [Field.teamDescription, (Field.teamDescription as string).toLowerCase()],
-    [Field.teamDetails, (Field.teamDetails as string).toLowerCase()],
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, [teamId]);
 
 EntityMetadataMappings.Register(

--- a/entities/teamMemberCache/teamMemberCache.ts
+++ b/entities/teamMemberCache/teamMemberCache.ts
@@ -26,6 +26,7 @@ import {
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
 import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { TableConfiguration } from '../../lib/entityMetadataProvider';
 
 const type = new EntityMetadataType('TeamMemberCache');
 
@@ -41,6 +42,8 @@ interface ITeamMemberCacheProperties {
 }
 
 const teamId = 'teamId';
+
+const defaultTableName = 'teammembercache';
 
 const Field: ITeamMemberCacheProperties = {
   uniqueId: 'uniqueId',
@@ -89,9 +92,15 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
   return new TeamMemberCacheEntity();
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, Field.uniqueId);
+
 MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
-PostgresConfiguration.SetDefaultTableName(type, 'teammembercache');
+
+TableConfiguration.SetDefaultTableName(type, defaultTableName);
+TableConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
+TableConfiguration.SetFixedPartitionKey(type, defaultTableName);
+
+PostgresConfiguration.SetDefaultTableName(type, defaultTableName);
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'teammembercache');
 PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);

--- a/entities/teamMemberCache/teamMemberCache.ts
+++ b/entities/teamMemberCache/teamMemberCache.ts
@@ -25,7 +25,7 @@ import {
   PostgresConfiguration,
 } from '../../lib/entityMetadataProvider/postgres';
 import { stringOrNumberAsString } from '../../utils';
-import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
+import { MemoryConfiguration, MemorySettings } from '../../lib/entityMetadataProvider/memory';
 
 const type = new EntityMetadataType('TeamMemberCache');
 
@@ -89,37 +89,11 @@ EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityInstantiat
   return new TeamMemberCacheEntity();
 });
 EntityMetadataMappings.Register(type, MetadataMappingDefinition.EntityIdColumnName, Field.uniqueId);
-
-EntityMetadataMappings.Register(
-  type,
-  MemorySettings.MemoryMapping,
-  new Map<string, string>([
-    [Field.organizationId, 'orgid'],
-    [Field.teamId, 'teamName'],
-    [Field.userId, 'teamSlug'],
-    [Field.uniqueId, 'uniqueId'],
-    [Field.cacheUpdated, 'cached'],
-    [Field.teamRole, 'role'],
-    [Field.login, 'login'],
-    [Field.avatar, 'avatar'],
-  ])
-);
+MemoryConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 EntityMetadataMappings.RuntimeValidateMappings(type, MemorySettings.MemoryMapping, fieldNames, []);
 PostgresConfiguration.SetDefaultTableName(type, 'teammembercache');
 EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'teammembercache');
-PostgresConfiguration.MapFieldsToColumnNames(
-  type,
-  new Map<string, string>([
-    [Field.organizationId, (Field.organizationId as string).toLowerCase()],
-    [Field.uniqueId, (Field.uniqueId as string).toLowerCase()],
-    [Field.teamId, (Field.teamId as string).toLowerCase()],
-    [Field.userId, (Field.userId as string).toLowerCase()],
-    [Field.cacheUpdated, (Field.cacheUpdated as string).toLowerCase()],
-    [Field.teamRole, (Field.teamRole as string).toLowerCase()],
-    [Field.login, (Field.login as string).toLowerCase()],
-    [Field.avatar, (Field.avatar as string).toLowerCase()],
-  ])
-);
+PostgresConfiguration.MapFieldsToColumnNamesFromListLowercased(type, fieldNames);
 PostgresConfiguration.ValidateMappings(type, fieldNames, []);
 
 EntityMetadataMappings.Register(

--- a/entities/userSettings.ts
+++ b/entities/userSettings.ts
@@ -8,13 +8,13 @@ import {
   IEntityMetadataBaseOptions,
   EntityMetadataBase,
   IEntityMetadata,
-} from '../../lib/entityMetadataProvider/entityMetadata';
-import { QueryBase, IEntityMetadataFixedQuery } from '../../lib/entityMetadataProvider/query';
+} from '../lib/entityMetadataProvider/entityMetadata';
+import { QueryBase, IEntityMetadataFixedQuery } from '../lib/entityMetadataProvider/query';
 import {
   EntityMetadataMappings,
   MetadataMappingDefinition,
-} from '../../lib/entityMetadataProvider/declarations';
-import { PostgresConfiguration, PostgresSettings } from '../../lib/entityMetadataProvider/postgres';
+} from '../lib/entityMetadataProvider/declarations';
+import { PostgresConfiguration, PostgresSettings } from '../lib/entityMetadataProvider/postgres';
 
 const type = new EntityMetadataType('UserSettings');
 const thisProviderType = type;

--- a/github/tokenManager.ts
+++ b/github/tokenManager.ts
@@ -301,17 +301,21 @@ export class GitHubTokenManager {
       return;
     }
     let key = appConfig.appKey;
-    let fromLocalFile = false;
+    let skipDecodingBase64 = false;
     if (appConfig.appKeyFile) {
       key = await readFileToText(appConfig.appKeyFile);
-      fromLocalFile = true;
+      skipDecodingBase64 = true;
     }
     if (!key) {
       throw new Error(`appKey or appKeyFile required for ${purpose} GitHub App configuration`);
     }
+    if (key?.includes('-----BEGIN RSA')) {
+      // Not base64-encoded, use the CreateFromString method.
+      skipDecodingBase64 = true;
+    }
     const friendlyName = customPurpose?.name || appConfig.description || 'Unknown';
     const baseUrl = appConfig.baseUrl;
-    const app = fromLocalFile
+    const app = skipDecodingBase64
       ? GitHubAppTokens.CreateFromString(purpose, friendlyName, appId, key, baseUrl)
       : GitHubAppTokens.CreateFromBase64EncodedFileString(purpose, friendlyName, appId, key, baseUrl);
     this._apps.set(purpose, app);

--- a/interfaces/providers.ts
+++ b/interfaces/providers.ts
@@ -31,7 +31,6 @@ import { IUserSettingsProvider } from '../entities/userSettings';
 import { ICacheHelper } from '../lib/caching';
 import BlobCache from '../lib/caching/blob';
 import { ICampaignHelper } from '../lib/campaigns';
-import { ICorporateContactProvider } from '../lib/corporateContactProvider';
 import { RestLibrary } from '../lib/github';
 import { IGraphProvider } from '../lib/graphProvider';
 import { ILinkProvider } from '../lib/linkProviders';

--- a/lib/config/environmentConfigurationResolver.ts
+++ b/lib/config/environmentConfigurationResolver.ts
@@ -154,7 +154,9 @@ function createClient(options: IEnvironmentProviderOptions) {
             case 'integer':
             case 'int': {
               const attemptedValue = parseInt(currentValue as string, 10);
-              if (isNaN(attemptedValue)) {
+              if (currentValue === undefined) {
+                variableValue = currentValue;
+              } else if (isNaN(attemptedValue)) {
                 console.warn(
                   `The value "${currentValue}" for the env:// variable "${variableName}" is not a valid integer. Using the original value instead.`
                 );

--- a/lib/entityMetadataProvider/index.ts
+++ b/lib/entityMetadataProvider/index.ts
@@ -6,12 +6,16 @@
 import { IEntityMetadataProvider } from './entityMetadataProvider';
 import { ITableEntityMetadataProviderOptions, TableEntityMetadataProvider } from './table';
 import { IPostgresEntityMetadataProviderOptions, PostgresEntityMetadataProvider } from './postgres';
-import { MemoryEntityMetadataProvider } from './memory';
+import { MemoryConfiguration, MemoryEntityMetadataProvider, MemorySettings } from './memory';
 
 export * from './entityMetadataProvider';
 export * from './query';
 export * from './declarations';
 export * from './entityMetadata';
+
+export { MemoryConfiguration, MemorySettings };
+export { PostgresConfiguration, PostgresSettings } from './postgres';
+export { TableConfiguration, TableSettings } from './table';
 
 const providerTypes = ['memory', 'table', 'postgres'];
 

--- a/lib/entityMetadataProvider/memory.ts
+++ b/lib/entityMetadataProvider/memory.ts
@@ -167,3 +167,29 @@ export class MemoryEntityMetadataProvider implements IEntityMetadataProvider {
     };
   }
 }
+
+export class MemoryConfiguration {
+  static MapFieldsToColumnNames(
+    type: EntityMetadataType,
+    map: Map<string, string>,
+    lowercaseColumnNamesAutomatically?: boolean
+  ) {
+    const dest = new Map<string, string>();
+    for (const [key, value] of map.entries()) {
+      dest.set(key, lowercaseColumnNamesAutomatically ? value.toLowerCase() : value);
+    }
+    EntityMetadataMappings.Register(type, MemorySettings.MemoryMapping, dest);
+  }
+
+  static MapFieldsToColumnNamesFromListLowercased(type: EntityMetadataType, fieldNames: string[]) {
+    MemoryConfiguration.MapFieldsToColumnNames(
+      type,
+      new Map(
+        fieldNames.map((fieldName) => {
+          return [fieldName, fieldName];
+        })
+      ),
+      true
+    );
+  }
+}

--- a/lib/tableEntity.ts
+++ b/lib/tableEntity.ts
@@ -65,7 +65,10 @@ function mergeIntoEntity(entity: any, obj: any, callback?) {
         entity[key] = { type: 'Boolean', value } as Edm<'Boolean'>;
       } else if (Buffer.isBuffer(value)) {
         const asBuffer = value as Buffer;
-        entity[key] = { type: 'Binary', value: asBuffer.buffer } as Edm<'Binary'>;
+        entity[key] = {
+          type: 'Binary',
+          value: Buffer.from(asBuffer.buffer).toString('base64'),
+        } as Edm<'Binary'>;
       } else if (value instanceof Date) {
         const asDate = value as Date;
         entity[key] = { type: 'DateTime', value: asDate.toISOString() } as Edm<'DateTime'>;

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -103,7 +103,7 @@ export default function initMiddleware(
     if (!initializationError) {
       if (applicationProfile.sessions) {
         routePassport(app, passport, config);
-        if (config.github.organizations.onboarding && config.github.organizations.onboarding.length) {
+        if (config?.github?.organizations?.onboarding?.length > 0) {
           debug('Onboarding helper loaded');
           onboard(app, config);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "3.17.2",
-        "@azure/data-tables": "12.0.0-beta.2",
+        "@azure/data-tables": "13.2.1",
         "@azure/identity": "3.1.3",
         "@azure/keyvault-secrets": "4.6.0",
         "@azure/service-bus": "7.7.3",
@@ -309,15 +309,15 @@
       }
     },
     "node_modules/@azure/core-xml": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.0.0-beta.1.tgz",
-      "integrity": "sha512-7d2w0yd8pb1c9aj87JV/1ntOp+sCMcJ9QoGDxs6/7BLDh8Gb6kd2h3n+9JYhcLZO8wdHZb4d4GZgmRIwaAU72w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.3.2.tgz",
+      "integrity": "sha512-0YROtnH4dCq3NZwPsPsaTfeH/7PZLMuhCaeb/HkFcaaERQ0OFR0DOMgpP698yeDTXnKAl3kZdw72tgVtTqD2xQ==",
       "dependencies": {
-        "tslib": "^2.0.0",
-        "xml2js": "^0.4.19"
+        "fast-xml-parser": "^4.0.8",
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/cosmos": {
@@ -343,42 +343,22 @@
       }
     },
     "node_modules/@azure/data-tables": {
-      "version": "12.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-12.0.0-beta.2.tgz",
-      "integrity": "sha512-0bxVa9pTyeKjuLOMx+PGGfEOeY+JH1e1j3GrB7PrrFE8H3yB0RhqCZi5CSqojidgWuhYNK0nh5RG68v3WqQgcg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.2.1.tgz",
+      "integrity": "sha512-5pboUpSpxjTgZ499MxkLLR0i+lyUUwN6M5pTLZ2D4mUfKVz+vqiCijvxij0V0OfknMxVpQ+NrZcUdarw6a1Few==",
       "dependencies": {
+        "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.0.0",
         "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.0.0",
-        "@azure/core-tracing": "1.0.0-preview.11",
-        "@azure/core-xml": "1.0.0-beta.1",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-xml": "^1.0.0",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@azure/data-tables/node_modules/@azure/core-tracing": {
-      "version": "1.0.0-preview.11",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
-      "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
-      "dependencies": {
-        "@opencensus/web-types": "0.0.7",
-        "@opentelemetry/api": "1.0.0-rc.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@azure/data-tables/node_modules/@opentelemetry/api": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
-      "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==",
-      "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -497,18 +477,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/service-bus/node_modules/@azure/core-xml": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.3.0.tgz",
-      "integrity": "sha512-HYulCHr/3eMDxGubmbm+KIUxpOKPGtRxpaKBN6GpgPDQzREefdQ5bDlTuwHWhtqwyUG4RicKtZu8rhv5Sbg8jQ==",
-      "dependencies": {
-        "fast-xml-parser": "^4.0.8",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -2417,14 +2385,6 @@
       "integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
       "dependencies": {
         "@octokit/openapi-types": "^13.11.0"
-      }
-    },
-    "node_modules/@opencensus/web-types": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
-      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g==",
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -11164,12 +11124,12 @@
       }
     },
     "@azure/core-xml": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.0.0-beta.1.tgz",
-      "integrity": "sha512-7d2w0yd8pb1c9aj87JV/1ntOp+sCMcJ9QoGDxs6/7BLDh8Gb6kd2h3n+9JYhcLZO8wdHZb4d4GZgmRIwaAU72w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.3.2.tgz",
+      "integrity": "sha512-0YROtnH4dCq3NZwPsPsaTfeH/7PZLMuhCaeb/HkFcaaERQ0OFR0DOMgpP698yeDTXnKAl3kZdw72tgVtTqD2xQ==",
       "requires": {
-        "tslib": "^2.0.0",
-        "xml2js": "^0.4.19"
+        "fast-xml-parser": "^4.0.8",
+        "tslib": "^2.2.0"
       }
     },
     "@azure/cosmos": {
@@ -11192,35 +11152,19 @@
       }
     },
     "@azure/data-tables": {
-      "version": "12.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-12.0.0-beta.2.tgz",
-      "integrity": "sha512-0bxVa9pTyeKjuLOMx+PGGfEOeY+JH1e1j3GrB7PrrFE8H3yB0RhqCZi5CSqojidgWuhYNK0nh5RG68v3WqQgcg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.2.1.tgz",
+      "integrity": "sha512-5pboUpSpxjTgZ499MxkLLR0i+lyUUwN6M5pTLZ2D4mUfKVz+vqiCijvxij0V0OfknMxVpQ+NrZcUdarw6a1Few==",
       "requires": {
+        "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.0.0",
         "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.0.0",
-        "@azure/core-tracing": "1.0.0-preview.11",
-        "@azure/core-xml": "1.0.0-beta.1",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-xml": "^1.0.0",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "@azure/core-tracing": {
-          "version": "1.0.0-preview.11",
-          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
-          "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
-          "requires": {
-            "@opencensus/web-types": "0.0.7",
-            "@opentelemetry/api": "1.0.0-rc.0",
-            "tslib": "^2.0.0"
-          }
-        },
-        "@opentelemetry/api": {
-          "version": "1.0.0-rc.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
-          "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
-        }
       }
     },
     "@azure/identity": {
@@ -11318,17 +11262,6 @@
         "process": "^0.11.10",
         "rhea-promise": "^2.1.0",
         "tslib": "^2.2.0"
-      },
-      "dependencies": {
-        "@azure/core-xml": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.3.0.tgz",
-          "integrity": "sha512-HYulCHr/3eMDxGubmbm+KIUxpOKPGtRxpaKBN6GpgPDQzREefdQ5bDlTuwHWhtqwyUG4RicKtZu8rhv5Sbg8jQ==",
-          "requires": {
-            "fast-xml-parser": "^4.0.8",
-            "tslib": "^2.2.0"
-          }
-        }
       }
     },
     "@azure/storage-blob": {
@@ -12914,11 +12847,6 @@
       "requires": {
         "@octokit/openapi-types": "^13.11.0"
       }
-    },
-    "@opencensus/web-types": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
-      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
     },
     "@opentelemetry/api": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "//...": "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ",
   "dependencies": {
     "@azure/cosmos": "3.17.2",
-    "@azure/data-tables": "12.0.0-beta.2",
+    "@azure/data-tables": "13.2.1",
     "@azure/identity": "3.1.3",
     "@azure/keyvault-secrets": "4.6.0",
     "@azure/service-bus": "7.7.3",

--- a/routes/administration/app.ts
+++ b/routes/administration/app.ts
@@ -68,23 +68,12 @@ router.get(
   })
 );
 
-function getOrganizationConfiguration(config: any, orgName: string) {
-  orgName = orgName.toLowerCase();
-  if (config.github && config.github.organizations) {
-    for (const entry of config.github.organizations) {
-      if (entry && entry.name && entry.name.toLowerCase() === orgName) {
-        return entry;
-      }
-    }
-  }
-}
-
 router.use(
   '/:appId/installations/:installationId',
   asyncHandler(async function (req: ReposAppRequest, res, next) {
     const githubApplication = req['githubApplication'] as GitHubApplication;
     const installationIdString = req.params.installationId;
-    const { config, organizationSettingsProvider } = getProviders(req);
+    const { operations, organizationSettingsProvider } = getProviders(req);
     const installationId = Number(installationIdString);
     const installation = await githubApplication.getInstallation(installationId);
     const invalidReasons = GitHubApplication.isInvalidInstallation(installation);
@@ -99,7 +88,7 @@ router.use(
     } catch (notFound) {
       /* ignored */
     }
-    const staticSettings = getOrganizationConfiguration(config, organizationName);
+    const staticSettings = operations.getOrganizationSettings(organizationName);
 
     req['installationConfiguration'] = {
       staticSettings,


### PR DESCRIPTION
This aligns the organization "dynamic" and static settings approach in the main operations routines to be more consistent. This introduces an improved ability to have org configuration come in through the environment system.

Introduces "installations discovery" routine, optionally, for organization settings that will find the installation IDs at startup instead of requiring this to be hard-coded into the app. Makes modern GitHub Apps use much better.

## Other changes

Latest Azure tables client and additional table mapping support.

## Breaking changes

It's possible that org settings that are static may need to include `active: true` in their config. This is to better align to an explicit opt-in method.