### PR TITLE
Ensure the redis key is set before attempting to auth with it.

### DIFF
--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -592,7 +592,11 @@ async function connectRedis(
   debug(`connecting to ${purpose} Redis ${redisConfig.host || redisConfig.tls}`);
   const redisClient: RedisClientType = createClient(redisOptions);
   await redisClient.connect();
-  await redisClient.auth({ password: config.redis.key });
+
+  if (config.redis.key) {
+    await redisClient.auth({ password: config.redis.key });
+  }
+
   return redisClient;
 }
 


### PR DESCRIPTION
Without this, start-up fails in a local dev environment when using the base Redis container and no auth.

```
TypeError: Invalid argument type
    at encodeCommand (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/client/RESP2/encoder.js:17:19)
    at RedisCommandsQueue.getCommandToSend (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/client/commands-queue.js:138:45)
    at Commander._RedisClient_tick (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/client/index.js:507:76)
    at Commander._RedisClient_sendCommand (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/client/index.js:494:82)
    at Commander.commandsExecutor (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/client/index.js:193:154)
    at Commander.BaseClass.<computed> [as auth] (/Users/garnertb/projects/github-portal/node_modules/@redis/client/dist/lib/commander.js:8:29)
    at connectRedis (/Users/garnertb/projects/github-portal/dist/middleware/initialize.js:535:23)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async initializeAsync (/Users/garnertb/projects/github-portal/dist/middleware/initialize.js:85:29)
    at async initialize (/Users/garnertb/projects/github-portal/dist/middleware/initialize.js:396:13)
```