### PR TITLE
chore: group Dependabot minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,16 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
Updates the Dependabot config so minor/patch updates will be combined as a single PR, but major versions will still get their own separate PRs.
Changed the frequency to weekly to reduce noise.