### PR TITLE
ci: don't autoclose Dependabot PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,14 +15,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message:
-            This issue has been identified as stale because it
+          stale-issue-message: This issue has been identified as stale because it
             has gone 30 days with no activity.
 
             The issue will be closed in 10 days. If this is incorrect,
             simply comment on the issue, or remove the stale label.
-          stale-pr-message:
-            This pull request has been identified as stale because
+          stale-pr-message: This pull request has been identified as stale because
             it has gone 30 days with no activity.
 
             The pull request will be closed in 10 days. If this is incorrect,
@@ -32,5 +30,5 @@ jobs:
             you **can merge it yourself.**
           days-before-stale: 30
           days-before-close: 10
-          exempt-issue-labels: "keep-me"
-          exempt-pr-labels: "keep-me"
+          exempt-issue-labels: 'keep-me'
+          exempt-pr-labels: 'keep-me,dependencies'


### PR DESCRIPTION
Dependabot will replace PRs as they come in, and is already limited to the number it will open. Auto-closing them might mean a security or bump PR won't get opened again by Dependabot